### PR TITLE
VTA-1568: Add in Welsh Defects

### DIFF
--- a/tests/resources/defects.json
+++ b/tests/resources/defects.json
@@ -3,6 +3,7 @@
     "id": 1,
     "imNumber": 1,
     "imDescription": "Registration Plate",
+    "imDescriptionWelsh": "Plât Cofrestru",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -35,6 +36,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A registration plate:",
+        "itemDescriptionWelsh": "Plât cofrestru:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -43,6 +45,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -52,6 +55,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -60,6 +64,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A registration mark:",
+        "itemDescriptionWelsh": "Marc cofrestru",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -68,6 +73,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -77,6 +83,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "illegible.",
+            "deficiencyTextWelsh": "annarllenadwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -86,6 +93,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not in accordance with the requirements.",
+            "deficiencyTextWelsh": "ddim yn unol â'r gofynion.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -97,6 +105,7 @@
     "id": 2,
     "imNumber": 3,
     "imDescription": "Seat Belts & Supplementary Restraint Systems",
+    "imDescriptionWelsh": "Gwregysau Diogelwch a Systemau Atal Atodol",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -132,6 +141,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Obligatory Seat Belt:",
+        "itemDescriptionWelsh": "Gwregys Diogelwch Gorfodol:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -140,6 +150,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -149,6 +160,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "of an incorrect type.",
+            "deficiencyTextWelsh": "o fath anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -157,6 +169,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Anchorages:",
+        "itemDescriptionWelsh": "Angorfeydd:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -165,6 +178,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with excessive corrosion, serious deterioration or a fracture in a load bearing member of the vehicle structure within 30cm of the anchorage (where a seat belt is attached to a seat frame this will apply to all seat mounting points).",
+            "deficiencyTextWelsh": "gyda rhydu gormodol, dirywiad difrifol neu doriad mewn aelod sy'n cynnal llwyth o strwythur y cerbyd o fewn 30cm i'r angorfa (lle mae gwregys diogelwch ynghlwm wrth ffrâm sedd bydd hyn yn berthnasol i bob pwynt gosod sedd).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -174,6 +188,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with excessive corrosion, serious deterioration or a fracture in a load bearing member of the vehicle structure within 30cm of the anchorage (where a seat belt is attached to a seat frame this will apply to all seat mounting points) and is likely to detach.",
+            "deficiencyTextWelsh": "gyda rhydu gormodol, dirywiad difrifol neu doriad mewn aelod sy'n cynnal llwyth o strwythur y cerbyd o fewn 30cm i'r angorfa (lle mae gwregys diogelwch ynghlwm wrth ffrâm sedd bydd hyn yn berthnasol i bob pwynt gosod sedd) ac mae'n debygol o ddatgysylltu.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -183,6 +198,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a seat belt not securely fixed to the seat or to the vehicle structure.",
+            "deficiencyTextWelsh": "gwregys diogelwch nad yw wedi'i osod yn ddiogel ar y sedd nac ar strwythur y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -191,6 +207,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Locking Mechanism, Stalks, Retracting Mechanism and Fittings:",
+        "itemDescriptionWelsh": "Mecanwaith Cloi, Coesynnau, Mecanwaith Tynnu'n Ôl a Ffitiadau:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -199,6 +216,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "locking mechanism of a seat belt does not secure or release as intended.",
+            "deficiencyTextWelsh": "nid yw mecanwaith cloi gwregys diogelwch yn diogelu nac yn rhyddhau fel y bwriadwyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -208,6 +226,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an attachment or adjustment fitting fractured, badly deteriorated or not operating effectively.",
+            "deficiencyTextWelsh": "atodiad neu ffitiad addasiad wedi torri, wedi dirywio'n wael neu ddim yn gweithredu'n effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -217,6 +236,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "corrosion or deterioration of a flexible stalk likely to lead to failure under load.",
+            "deficiencyTextWelsh": "cyrydiad neu ddirywiad coesyn hyblyg sy'n debygol o arwain at fethiant dan lwyth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -226,6 +246,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "broken flexible stalk strands",
+            "deficiencyTextWelsh": "broken flexible stalk strands",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -235,6 +256,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a retracting mechanism that does not retract the webbing sufficiently to remove all of the slack from the belt with the locking mechanism fastened and the seat unoccupied.",
+            "deficiencyTextWelsh": "mecanwaith tynnu'n ôl nad yw'n tynnu'r webin yn ôl yn ddigonol i dynnu'r holl slac o'r gwregys gyda'r mecanwaith cloi wedi'i gau a'r sedd yn wag.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -243,6 +265,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Condition of Webbing:",
+        "itemDescriptionWelsh": "Cyflwr Webin:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -251,6 +274,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "a cut or damage or fluffing or fraying, which is not sufficient to obstruct correct operation of the belt or which has not clearly weakened the webbing.",
+            "deficiencyTextWelsh": "toriad neu ddifrod neu fflwffio neu ffraeo, nad yw'n ddigon i rwystro gweithrediad cywir y gwregys neu nad yw wedi gwanhau'r webin yn amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -260,6 +284,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "a cut or damage or fluffing or fraying or overstretching sufficient to obstruct correct operation of the belt or significantly weaken the webbing.",
+            "deficiencyTextWelsh": "toriad neu ddifrod neu fflwffio neu ffraeo neu or-ymestyn digon i rwystro gweithrediad cywir y gwregys neu wanhau'r webin yn sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -269,6 +294,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "stitching badly frayed, insecure, incomplete or repaired.",
+            "deficiencyTextWelsh": "pwytho wedi ffraeo'n wael, yn ansicr, yn anghyflawn neu wedi'i atgyweirio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -278,6 +304,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "so dirty that it is likely to soil passengers’ clothing.",
+            "deficiencyTextWelsh": "mor fudr fel ei fod yn debygol o faeddu dillad teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -286,6 +313,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Obvious signs of structural weakness in a Seat belt; fitting, guide,stalk or pivot",
+        "itemDescriptionWelsh": "Arwyddion amlwg o wendid strwythurol mewn Gwregys diogelwch; ffitiad, canllaw, coesyn neu golyn",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -294,6 +322,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "such that failure is likely.",
+            "deficiencyTextWelsh": "fel bod methiant yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -302,6 +331,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Seats with seat belts attached to them:",
+        "itemDescriptionWelsh": "Seddi gyda gwregysau diogelwch ynghlwm wrthynt:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -310,6 +340,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -319,6 +350,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a cracked or fractured leg or frame.",
+            "deficiencyTextWelsh": "gyda choes neu ffrâm wedi cracio neu wedi torri.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -327,6 +359,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "A seat belt:",
+        "itemDescriptionWelsh": "Gwregys diogelwch:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -335,6 +368,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "load limiter or pretensioner obviously missing where fitted as original equipment.",
+            "deficiencyTextWelsh": "cyfyngwr llwyth neu ragfynegydd yn amlwg ar goll lle y gosodwyd fel offer gwreiddiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -344,6 +378,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pretensioner or a ‘folded type’ webbing load limiter obviously deployed.",
+            "deficiencyTextWelsh": "mae'n amlwg bod rhagfynegydd neu gyfyngwr llwyth gwe 'math wedi'i blygu' yn cael ei ddefnyddio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -352,6 +387,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "An airbag:",
+        "itemDescriptionWelsh": "Bag aer:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -360,6 +396,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -369,6 +406,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "deployed or disconnected.",
+            "deficiencyTextWelsh": "cael ei ddefnyddio neu ei ddatgysylltu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -377,6 +415,7 @@
       {
         "itemNumber": 9,
         "itemDescription": "The SRS warning lamp",
+        "itemDescriptionWelsh": "Y lamp rhybudd SRS",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -385,6 +424,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "indicates any kind of failure of the system.",
+            "deficiencyTextWelsh": "yn dynodi unrhyw fath o fethiant y system.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -393,6 +433,7 @@
       {
         "itemNumber": 10,
         "itemDescription": "Installation defect found during annual test:",
+        "itemDescriptionWelsh": "Diffyg gosod a ganfuwyd yn ystod y prawf blynyddol:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -401,6 +442,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any obvious installation defect found during the inspection.",
+            "deficiencyTextWelsh": "unrhyw ddiffyg gosod amlwg a ganfuwyd yn ystod yr arolygiad.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -409,6 +451,7 @@
       {
         "itemNumber": 11,
         "itemDescription": "Installation inspection:",
+        "itemDescriptionWelsh": "Archwiliad gosod:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -417,6 +460,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "evidence that original webbing has been cut and/or reworked (e.g. belts knotted, fraying or fluffing removed/sealed by burning etc.).",
+            "deficiencyTextWelsh": "tystiolaeth bod webin gwreiddiol wedi’i dorri a/neu ei ail-weithio (e.e. gwregysau wedi’u clymu, rhwbio neu fflwffio wedi’u tynnu/selio trwy losgi ac ati).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -426,6 +470,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any part of the installation which has a sharp edge which could or is likely to cut or abrade the webbing.",
+            "deficiencyTextWelsh": "unrhyw ran o'r gosodiad sydd ag ymyl siarp a allai neu sy'n debygol o dorri neu sgrafellu'r webin.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -435,6 +480,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a directly attached anchorage not secured by standard seat belt mounting bolts and washers as detailed in paragraph D.",
+            "deficiencyTextWelsh": "angorfa sydd wedi’i chysylltu’n uniongyrchol nad yw wedi’i ddiogelu gan folltau gosod gwregysau diogelwch safonol a wasieri fel y nodir ym mharagraff D.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -444,6 +490,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an anchorage insecure.",
+            "deficiencyTextWelsh": "angorfa ansicr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -453,6 +500,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a tubular seat frame that has been drilled for the purpose of attaching a seat belt.",
+            "deficiencyTextWelsh": "ffrâm sedd tiwbaidd sydd wedi'i drilio at ddiben gosod gwregys diogelwch.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -462,6 +510,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a directly attached anchorage not attached to a load bearing member or without suitable reinforcement.",
+            "deficiencyTextWelsh": "angorfa sydd wedi'i chysylltu'n uniongyrchol nad yw ynghlwm wrth aelod sy'n cynnal llwyth neu heb atgyfnerthiad addas.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -471,6 +520,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "retro-fitted three point belt which is not mounted on a suitable structure.",
+            "deficiencyTextWelsh": "gwregys tri phwynt wedi'i ôl-osod nad yw wedi'i osod ar strwythur addas.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -480,6 +530,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tubular frame legs or tubular “H” pattern legs which have not been reinforced with buttressing and diagonal bracing, or buttressing where a floor mounted belt is fitted close to a seat leg.",
+            "deficiencyTextWelsh": "coesau ffrâm tiwbaidd neu goesau patrwm “H” tiwbaidd nad ydynt wedi'u hatgyfnerthu â bwtres a ffreision croeslin, neu fwtres lle mae gwregys wedi'i osod ar y llawr wedi'i osod yn agos at goes sedd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -489,6 +540,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "belt fitted to a seat which has not been suitably reinforced or modified.",
+            "deficiencyTextWelsh": "gwregys wedi'i osod ar sedd nad yw wedi'i hatgyfnerthu neu ei haddasu'n addas.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -498,6 +550,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "without suitable padding as detailed in paragraph L.",
+            "deficiencyTextWelsh": "heb padin addas fel y manylir ym mharagraff L.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -507,6 +560,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "lower anchorages less than 320 mm apart.",
+            "deficiencyTextWelsh": "angorfeydd is llai na 320 mm oddi wrth ei gilydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -516,6 +570,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "in such a position that loading the belt causes the cushion to be raised or significantly compressed thus allowing the occupant to effectively move forward.",
+            "deficiencyTextWelsh": "mewn sefyllfa fel bod llwytho'r gwregys yn achosi i'r clustog gael ei godi neu ei gywasgu'n sylweddol gan ganiatáu i'r deiliad symud ymlaen yn effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -525,6 +580,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an anchorage attached to the floor without reinforcement plates of a suitable size and contour.",
+            "deficiencyTextWelsh": "angorfa ynghlwm wrth y llawr heb blatiau atgyfnerthu o faint a chyfuchlin addas.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -534,6 +590,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with load spreading washer(s) missing from anchorage bolt.",
+            "deficiencyTextWelsh": "gyda wasier(i) taenu llwyth ar goll o'r bollt angori.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -543,6 +600,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "claw type seat mounting with inadequate means of securing claw.",
+            "deficiencyTextWelsh": "mowntin sedd math crafanc gyda dull annigonol o sicrhau crafanc.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -552,6 +610,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "on a seat fitted to a flat rail the bolt does not pass through the leg, rail, floor and a suitable structural member or the floor has not been suitably reinforced.",
+            "deficiencyTextWelsh": "ar sedd sydd wedi'i osod ar reilen wastad nid yw'r bollt yn mynd drwy'r goes, rheilen, llawr ac aelod strwythurol addas neu nid yw'r llawr wedi'i atgyfnerthu'n addas.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -561,6 +620,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tracking for securing seats and wheelchairs insecure.",
+            "deficiencyTextWelsh": "tracio ar gyfer sicrhau seddi a chadeiriau olwyn yn ansicr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -570,6 +630,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "free movement for a looped belt more than 25mm at the anchorage.",
+            "deficiencyTextWelsh": "symudiad rhydd ar gyfer gwregys dolennog mwy na 25mm wrth yr angorfa.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -579,6 +640,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "upper anchorage of three point belt less than 475 mm above uncompressed seat cushion measured parallel to the seat back.",
+            "deficiencyTextWelsh": "angorfa uchaf o wregys tri phwynt llai na 475 mm uwchben clustog sedd anghywasgedig wedi'i fesur yn gyfochrog â'r sedd yn ôl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -588,6 +650,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "upper anchorage of three point belt(s) less than 110 mm from centre line of seat.",
+            "deficiencyTextWelsh": "angorfa uchaf gwregys(au) tri phwynt llai na 110 mm o linell ganol y sedd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -597,6 +660,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incorrect positioning of a lap belt or lap section of a three point belt. i.e. the belt lies across the stomach or forward of the top quarter of the thigh.",
+            "deficiencyTextWelsh": "lleoliad anghywir gwregys glin neu adran lin gwregys tri phwynt. h.y. mae’r gwregys yn gorwedd ar draws y stumog neu flaen chwarter uchaf y glun.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -606,6 +670,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a seat belt component fitted to a seat significantly intrudes into a gangway and is likely to cause injury to a passenger.",
+            "deficiencyTextWelsh": "mae elfen gwregys diogelwch sydd wedi'i osod ar sedd yn ymwthio'n sylweddol i'r groesffordd ac yn debygol o achosi anaf i deithiwr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -615,6 +680,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "for vehicles subject to enhanced seat belt requirements no evidence that seat belt anchorages are likely to meet the strength requirements of EC directive 76/115/EC as amended by directive 96/38/EC.",
+            "deficiencyTextWelsh": "ar gyfer cerbydau sy'n destun gofynion gwregysau diogelwch uwch dim tystiolaeth bod angorfeydd gwregysau diogelwch yn debygol o fodloni gofynion cryfder cyfarwyddeb 76/115/EC y CE fel y diwygiwyd gan gyfarwyddeb 96/38/EC.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -626,6 +692,7 @@
     "id": 3,
     "imNumber": 5,
     "imDescription": "Exhaust Emissions",
+    "imDescriptionWelsh": "Allyriadau gwacáu",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -658,6 +725,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Compression Ignition Engines Statutory Visual Test:",
+        "itemDescriptionWelsh": "Prawf Gweledol Statudol Peiriannau Tanio Cywasgu:",
         "forVehicleType": ["hgv", "psv"],
         "deficiencies": [
           {
@@ -666,6 +734,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "After a maximum of six accelerations the exhaust emits smoke of a level greater than that of equivalent metered levels.",
+            "deficiencyTextWelsh": "Ar ôl uchafswm o chwe chyflymiad mae'r ecsôst yn allyrru mwg o lefel uwch na'r lefelau cyfatebol â mesurydd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -675,6 +744,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "The exhaust emits excessive smoke or vapour, of any colour, to an extent likely to obscure vision.",
+            "deficiencyTextWelsh": "Mae'r piben wacáu yn allyrru gormod o fwg neu anwedd, o unrhyw liw, i raddau sy'n debygol o guddio golwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -684,6 +754,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "After a maximum of six accelerations, the exhaust emits smoke of a level greater than that of equivalent metered levels.",
+            "deficiencyTextWelsh": "Ar ôl uchafswm o chwe chyflymiad mae'r ecsôst yn allyrru mwg o lefel uwch na'r lefelau cyfatebol â mesurydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -692,6 +763,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Emission control equipment fitted by the manufacturer",
+        "itemDescriptionWelsh": "Offer rheoli allyriadau a osodwyd gan y gwneuthurwr",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -700,6 +772,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "absent, or obviously defective or shows any signs of obvious tampering.",
+            "deficiencyTextWelsh": "absennol, neu'n amlwg yn ddiffygiol neu'n dangos unrhyw arwyddion o ymyrryd amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -708,6 +781,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "A vehicle equipped with a Diesel Particulate Filter",
+        "itemDescriptionWelsh": "Cerbyd sydd â Hidlydd Gronynnol Diesel",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -716,6 +790,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "shows any visible signs of smoke.",
+            "deficiencyTextWelsh": "yn dangos unrhyw arwyddion amlwg o fwg.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -724,6 +799,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Engine MIL",
+        "itemDescriptionWelsh": "Injan MIL",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -732,6 +808,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "inoperative or indicating a malfunction.",
+            "deficiencyTextWelsh": "anweithredol neu'n dynodi camweithio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -740,6 +817,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Compression Ignition Engines Statutory Smoke Meter Test:",
+        "itemDescriptionWelsh": "Prawf Mesurydd Mwg Statudol Peiriannau Tanio Cywasgu:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -748,6 +826,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "After a total of six accelerations have been completed, the average smoke opacity recorded for accelerations 4, 5 and 6 is more than: For vehicles first used before 1 July 2008: The level specified on the manufacturer’s plate or 2.5m-1 for non-turbocharged engines, where the plate value is not available.",
+            "deficiencyTextWelsh": "Ar ôl cwblhau cyfanswm o chwe chyflymiad, mae'r didreiddedd mwg cyfartalog a gofnodwyd ar gyfer cyflymiadau 4, 5 a 6 yn fwy na: Ar gyfer cerbydau a ddefnyddiwyd gyntaf cyn 1 Gorffennaf 2008: Y lefel a nodir ar blât y gwneuthurwr neu 2.5m-1 ar gyfer cerbydau nad ydynt yn injans llawn potensial, lle nad yw'r gwerth plât ar gael. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -757,6 +836,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "After a total of six accelerations have been completed, the average smoke opacity recorded for accelerations 4, 5 and 6 is more than: For vehicles first used before 1 July 2008: The level specified on the manufacturer’s plate or 3.0m-1  for turbocharged engines, where the plate value is not available.",
+            "deficiencyTextWelsh": "Ar ôl cwblhau cyfanswm o chwe chyflymiad, mae'r didreiddedd mwg cyfartalog a gofnodwyd ar gyfer cyflymiadau 4, 5 a 6 yn fwy na: Ar gyfer cerbydau a ddefnyddiwyd gyntaf cyn 1 Gorffennaf 2008: Y lefel a nodir ar blât y gwneuthurwr neu 3.0m-1 ar gyfer injans llawn potensial, lle nad yw'r gwerth plât ar gael. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -766,6 +846,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "major",
             "deficiencyText": "After a total of six accelerations have been completed, the average smoke opacity recorded for accelerations 4, 5 and 6 is more than: For vehicles first used from 1 July 2008: The level specified on the manufacturer’s plate or 1.5m-1 for all CI engines, where the plate value is not available.",
+            "deficiencyTextWelsh": "Ar ôl cwblhau cyfanswm o chwe chyflymiad, mae'r didreiddedd mwg cyfartalog a gofnodwyd ar gyfer cyflymiadau 4, 5 a 6 yn fwy na: Ar gyfer cerbydau a ddefnyddiwyd gyntaf o 1 Gorffennaf 2008: Y lefel a nodir ar blât y gwneuthurwr neu 1.5m-1 ar gyfer pob injans CI, lle nad yw'r gwerth plât ar gael. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -775,6 +856,7 @@
             "deficiencySubId": "iv",
             "deficiencyCategory": "major",
             "deficiencyText": "After a total of six accelerations have been completed, the average smoke opacity recorded for accelerations 4, 5 and 6 is more than: For vehicles first used from 1 January 2014: The level specified on the manufacturer’s plate or 0.7m-1 for all CI engines, where the plate value is not available.",
+            "deficiencyTextWelsh": "Ar ôl cwblhau cyfanswm o chwe chyflymiad, mae'r didreiddedd mwg cyfartalog a gofnodwyd ar gyfer cyflymiadau 4, 5 a 6 yn fwy na: Ar gyfer cerbydau a ddefnyddiwyd gyntaf o 1 Ionawr 2014: Y lefel a nodir ar blât y gwneuthurwr neu 0.7m-1 ar gyfer pob CI injans, lle nad yw'r gwerth plât ar gael. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -784,6 +866,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "The exhaust emits excessive smoke or vapour of any colour, to an extent likely to obscure vision.",
+            "deficiencyTextWelsh": "Mae'r piben wacáu yn allyrru gormod o fwg neu anwedd o unrhyw liw, i raddau sy'n debygol o guddio golwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -792,6 +875,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Spark Ignition Engines Visual Check:",
+        "itemDescriptionWelsh": "Gwiriad Gweledol Peiriannau Tanio Gwreichionen:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -800,6 +884,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "The engine is idling at a speed clearly above the normal idling speed.",
+            "deficiencyTextWelsh": "Mae'r injan yn segura ar gyflymder sy'n amlwg yn uwch na'r cyflymder segura arferol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -809,6 +894,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "The exhaust emits dense blue or clearly visible black smoke for a continuous period of 5 seconds at idling speed.",
+            "deficiencyTextWelsh": "Mae'r gwacáu yn allyrru mwg glas trwchus neu fwg du sy'n amlwg yn weladwy am gyfnod parhaus o 5 eiliad ar gyflymder segur.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -817,6 +903,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Spark Ignition Engines Exhaust Gas Analyser Check:",
+        "itemDescriptionWelsh": "Gwiriad Dadansoddwr Nwy Gwactod Peiriannau Tanio Gwreichionen:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -825,6 +912,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "HC content greater than: 1200ppm for a vehicle first used from 1 August 1975 to 1 August 1994.",
+            "deficiencyTextWelsh": "Cynnwys HC yn fwy na: 1200ppm ar gyfer cerbyd a ddefnyddiwyd gyntaf rhwng 1 Awst 1975 a 1 Awst 1994.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -834,6 +922,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "HC content greater than: 200ppm for a vehicle first used from 1 August 1994.",
+            "deficiencyTextWelsh": "Cynnwys HC yn fwy na: 200ppm ar gyfer cerbyd a ddefnyddiwyd gyntaf o 1 Awst 1994.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -843,6 +932,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "CO content greater than: 4.5% for a vehicle first used from 1 August 1975 to 31 July 1986.",
+            "deficiencyTextWelsh": "Cynnwys CO yn fwy na: 4.5% ar gyfer cerbyd a ddefnyddiwyd gyntaf rhwng 1 Awst 1975 a 31 Gorffennaf 1986.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -852,6 +942,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "CO content greater than: 3.5% for a vehicle first used from 1 August 1986 to 1 August 1994 and any LPG/CNG fuelled vehicles used from 1 August 1975.",
+            "deficiencyTextWelsh": "Cynnwys CO yn fwy na: 3.5% ar gyfer cerbyd a ddefnyddiwyd gyntaf rhwng 1 Awst 1986 ac 1 Awst 1994 ac unrhyw gerbydau tanwydd LPG/CNG a ddefnyddiwyd o 1 Awst 1975.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -861,6 +952,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "major",
             "deficiencyText": "CO content greater than: 0.2% at fast idle (2500 - 3000 rpm) for a vehicle first used from 1 August 1994",
+            "deficiencyTextWelsh": "Cynnwys CO yn fwy na: 0.2% yn gyflym segur (2500 - 3000 rpm) ar gyfer cerbyd a ddefnyddiwyd gyntaf o 1 Awst 1994",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -870,6 +962,7 @@
             "deficiencySubId": "iv",
             "deficiencyCategory": "major",
             "deficiencyText": "CO content greater than: 0.3% at idle (450  - 1500 rpm) for a vehicle first used from 1 August 1994",
+            "deficiencyTextWelsh": "Cynnwys CO yn fwy na: 0.3% yn segur (450 - 1500 rpm) ar gyfer cerbyd a ddefnyddiwyd gyntaf o 1 Awst 1994 ",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -879,6 +972,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Lambda not between: 0.97 and 1.03 for a vehicle first used from 1 August 1994",
+            "deficiencyTextWelsh": "Lambda ddim rhwng: 0.97 a 1.03 ar gyfer cerbyd a ddefnyddiwyd gyntaf o 1 Awst 1994",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -887,6 +981,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Emission control equipment fitted by the manufacturer",
+        "itemDescriptionWelsh": "Offer rheoli allyriadau a osodwyd gan y gwneuthurwr",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -895,6 +990,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "absent, or obviously defective or shows any signs of obvious tampering.",
+            "deficiencyTextWelsh": "absennol, neu'n amlwg yn ddiffygiol neu'n dangos unrhyw arwyddion o ymyrryd amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -903,6 +999,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "A vehicle equipped with a Diesel Particulate Filter",
+        "itemDescriptionWelsh": "Cerbyd sydd â Hidlydd Gronynnol Diesel",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -911,6 +1008,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "shows any visible signs of smoke.",
+            "deficiencyTextWelsh": "yn dangos unrhyw arwyddion amlwg o fwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -919,6 +1017,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "Engine MIL",
+        "itemDescriptionWelsh": "Injan MIL",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -927,6 +1026,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "inoperative or indicating a malfunction.",
+            "deficiencyTextWelsh": "anweithredol neu'n dynodi camweithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -938,6 +1038,7 @@
     "id": 4,
     "imNumber": 6,
     "imDescription": "Road Wheels and Hubs",
+    "imDescriptionWelsh": "Olwynion Ffyrdd a Hybiau",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -981,6 +1082,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A tyre retaining ring:",
+        "itemDescriptionWelsh": "Cylch cadw teiar:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -989,6 +1091,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fractured or not properly fitted such that detachment is likely.",
+            "deficiencyTextWelsh": "wedi torri neu heb ei ffitio'n iawn fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -998,6 +1101,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "butting causing the flange to lift more than 1.5mm from the rim and/or not properly fitted.",
+            "deficiencyTextWelsh": "bytio yn achosi i'r fflans godi mwy na 1.5mm o'r ymyl a/neu heb ei osod yn iawn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -1006,6 +1110,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A wheel:",
+        "itemDescriptionWelsh": "Olwyn:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -1014,6 +1119,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with any visible elongation of a stud hole.",
+            "deficiencyTextWelsh": "gydag unrhyw ehangiad gweladwy o dwll styden.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1023,6 +1129,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with any visible elongation of a stud hole where secure fixing of a wheel is affected.",
+            "deficiencyTextWelsh": "gydag unrhyw ehangiad gweladwy o dwll styden lle effeithir ar osod olwyn yn ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1032,6 +1139,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "badly damaged or distorted (including damaged by the corners of a wheel nut cutting into the material of the wheel).",
+            "deficiencyTextWelsh": "difrodi neu ystumio'n ddrwg (gan gynnwys difrodi gan gorneli nytiau olwyn yn torri i mewn i ddeunydd yr olwyn).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1041,6 +1149,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "badly damaged or distorted (including damaged by the corners of a wheel nut cutting into the material of the wheel) where secure fixing of the wheel is affected.",
+            "deficiencyTextWelsh": "difrodi neu ystumio'n ddrwg (gan gynnwys difrodi gan gorneli nytiau olwyn yn torri i mewn i ddeunydd yr olwyn) lle effeithir ar osod yr olwyn yn ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1050,6 +1159,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not compatible with its fixings.",
+            "deficiencyTextWelsh": "ddim yn gydnaws â'i osodiadau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1059,6 +1169,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cracked (except at the bridge over the valve), weld breaking away or an inadequate repair.",
+            "deficiencyTextWelsh": "wedi cracio (ac eithrio wrth y bont dros y falf), weldiad yn torri i ffwrdd neu atgyweiriad annigonol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1068,6 +1179,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "made of aluminium alloy repaired by welding.",
+            "deficiencyTextWelsh": "wedi'i wneud o aloi alwminiwm wedi'i atgyweirio gan weldio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1077,6 +1189,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a load rating less than that required to support the maximum permissible (GB) axle load.",
+            "deficiencyTextWelsh": "gyda sgôr llwyth yn llai na'r hyn sydd ei angen i gynnal y llwyth echel mwyaf a ganiateir (GB).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -1085,6 +1198,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A hub:",
+        "itemDescriptionWelsh": "Hyb:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -1093,6 +1207,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "cracked, badly damaged, or with a half shaft or wheel flange bolt, stud or nut loose or missing.",
+            "deficiencyTextWelsh": "cracio, difrodi'n ddrwg, neu gyda bollt hanner siafft, gre neu gneuen yn rhydd neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1102,6 +1217,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cracked, badly damaged, or with half shaft or wheel flange bolts, studs or nuts loose or missing where secure fixing of the wheel is affected.",
+            "deficiencyTextWelsh": "wedi cracio, wedi'i ddifrodi'n ddrwg, neu gyda bollt hanner siafft, styd neu gneuen yn rhydd neu ar goll pan effeithir ar osod yr olwyn yn ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1111,6 +1227,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with clearance between a spigot mounted wheel and the hub spigots that exceeds 3mm across the diameter.",
+            "deficiencyTextWelsh": "gyda chliriad rhwng olwyn wedi'i osod ar sbigot a'r hyb sbigots sy'n fwy na 3mm ar draws y diamedr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1120,6 +1237,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with a wheel retaining nut or stud missing or loose or obviously not fulfilling the function of clamping the wheel to the hub.",
+            "deficiencyTextWelsh": "gydag olwyn yn cadw cneuen neu gre ar goll neu'n rhydd neu'n amlwg ddim yn cyflawni swyddogaeth clampio'r olwyn i'r hyb.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1129,6 +1247,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with multiple wheel retaining nuts or studs missing or loose or obviously not fulfilling the function of clamping the wheel to the hub.",
+            "deficiencyTextWelsh": "gyda chneuen neu greoedd cadw olwyn lluosog ar goll neu'n rhydd neu'n amlwg ddim yn cyflawni swyddogaeth clampio'r olwyn i'r hyb.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1138,6 +1257,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a spigot wheel nut washer cracked.",
+            "deficiencyTextWelsh": "gyda golchwr cnau olwyn sbigot wedi cracio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1147,6 +1267,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a wheel locating spigot or dowel missing.",
+            "deficiencyTextWelsh": "gydag olwyn yn lleoli sbigot neu hoelbren ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -1158,6 +1279,7 @@
     "id": 5,
     "imNumber": 7,
     "imDescription": "Size and Type of Tyres",
+    "imDescriptionWelsh": "Maint a Math o Deiars",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -1201,6 +1323,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A tyre:",
+        "itemDescriptionWelsh": "Teiars:",
         "forVehicleType": ["hgv", "trl", "psv"],
         "deficiencies": [
           {
@@ -1209,6 +1332,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "of which the nominal size, ply rating, load index or speed rating of any tyre is below that appropriate for the plated axle weight.",
+            "deficiencyTextWelsh": "y mae maint nominal, graddiad haen, mynegai llwyth neu gyfradd cyflymder unrhyw deiar yn is na'r hyn sy'n briodol ar gyfer pwysau'r echel blatiau.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1218,6 +1342,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "of which the nominal size, ply rating, load index or speed rating of any tyre is below that appropriate for the plated axle weight and is loaded in excess of the tyre load index/ply rating.",
+            "deficiencyTextWelsh": "y mae maint nominal, graddiad haen, mynegai llwyth neu gyfradd cyflymder unrhyw deiar yn is na'r hyn sy'n briodol ar gyfer pwysau'r echel blatiog ac wedi'i lwytho'n uwch na mynegai llwyth y teiars/graddfa haenellu.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1227,6 +1352,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which has a tyre use marking inappropriate for the type of axle or vehicle to which it is fitted.",
+            "deficiencyTextWelsh": "sydd â marc defnydd teiar sy'n amhriodol ar gyfer y math o echel neu gerbyd y mae wedi'i osod arno.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1236,6 +1362,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "of a different nominal size to another on the same axle.",
+            "deficiencyTextWelsh": "o faint enwol gwahanol i un arall ar yr un echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1245,6 +1372,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "of a different structure to another on the same axle.",
+            "deficiencyTextWelsh": "o strwythur gwahanol i un arall ar yr un echel.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1254,6 +1382,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "on a steerable axle which is not of the same structure as any other tyre on any steerable axle",
+            "deficiencyTextWelsh": "ar echel y gellir ei lywio nad yw o'r un strwythur ag unrhyw deiar arall ar unrhyw echel y gellir ei lywio",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1263,6 +1392,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "on a driven axle which is not of the same structure as any other tyre on any driven axle.",
+            "deficiencyTextWelsh": "ar echel wedi'i yrru nad yw o'r un strwythur ag unrhyw deiar arall ar unrhyw echel a yrrir.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1272,6 +1402,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "of which the nominal size, ply rating, load index or speed rating of any tyre is below that appropriate for the axle weight.",
+            "deficiencyTextWelsh": "y mae maint nominal, graddiad haen, mynegai llwyth neu gyfradd cyflymder unrhyw deiar yn is na'r hyn sy'n briodol ar gyfer pwysau'r echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -1281,6 +1412,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "of which the nominal size, ply rating, load index or speed rating of any tyre is below that appropriate for the axle weight and is loaded in excess of the tyre load index/ply rating.",
+            "deficiencyTextWelsh": "y mae maint nominal, graddiad haen, mynegai llwyth neu gyfradd cyflymder unrhyw deiar yn is na'r hyn sy'n briodol ar gyfer pwysau'r echel ac wedi'i lwytho'n uwch na mynegai llwyth y teiars/graddfa haenellu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -1289,6 +1421,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A Tyre: On a two axle motor vehicle fitted with single tyres on both axles",
+        "itemDescriptionWelsh": "Teiars: Ar gerbyd modur dwy echel sydd â theiars sengl ar y ddwy echel",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -1297,6 +1430,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a combination of tyres with structures which are not shown as acceptable in the table.",
+            "deficiencyTextWelsh": "cyfuniad o deiars gyda strwythurau nad ydynt yn cael eu dangos yn dderbyniol yn y tabl.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -1308,6 +1442,7 @@
     "id": 6,
     "imNumber": 8,
     "imDescription": "Condition of Tyres",
+    "imDescriptionWelsh": "Cyflwr Teiars",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -1351,6 +1486,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A tyre:",
+        "itemDescriptionWelsh": "Teiars:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -1359,6 +1495,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a cut which is deep enough to reach the ply or cords, and is more than 25mm long, or 10% of the section width, whichever is greater.",
+            "deficiencyTextWelsh": "gyda thoriad sy'n ddigon dwfn i gyrraedd y plyg neu'r cortynnau, ac sy'n fwy na 25mm o hyd, neu 10% o led yr adran, pa bynnag sydd fwyaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1368,6 +1505,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with a lump, bulge or tear caused by separation or partial failure of its structure, including any lifting of the tread rubber.",
+            "deficiencyTextWelsh": "gyda lwmp, chwydd neu rwyg a achosir gan wahaniad neu fethiant rhannol yn ei strwythur, gan gynnwys unrhyw godiad o'r rwber gwadn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1377,6 +1515,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with exposed ply or cord.",
+            "deficiencyTextWelsh": "gyda plyg neu linyn agored.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1386,6 +1525,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "rubbing on any part of the vehicle.",
+            "deficiencyTextWelsh": "rhwbio ar unrhyw ran o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1395,6 +1535,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "fouling on any part of the vehicle and safe driving not impaired.",
+            "deficiencyTextWelsh": "baeddu ar unrhyw ran o'r cerbyd a gyrru diogel heb ei amharu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1404,6 +1545,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fouling on any part of the vehicle and safe driving is impaired.",
+            "deficiencyTextWelsh": "baeddu ar unrhyw ran o'r cerbyd ac amhariad ar yrru'n ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1413,6 +1555,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incorrectly seated on its wheel.",
+            "deficiencyTextWelsh": "eistedd yn anghywir ar ei olwyn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1422,6 +1565,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "obviously underinflated.",
+            "deficiencyTextWelsh": "yn amlwg wedi'i danchwythu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1431,6 +1575,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "where the base of any groove of the original tread pattern is not clearly visible.",
+            "deficiencyTextWelsh": "lle nad yw gwaelod unrhyw rigol o'r patrwm gwadn gwreiddiol i'w weld yn glir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1440,6 +1585,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "where the minimum tread depth and tread band requirements are not met.",
+            "deficiencyTextWelsh": "lle na fodlonir y dyfnder gwadn lleiaf a'r gofynion band gwadn.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1449,6 +1595,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "in excess of ten years of age fitted to any front steered axle of a vehicle.",
+            "deficiencyTextWelsh": "dros ddeng mlwydd oed wedi'i osod ar unrhyw echel flaen cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -1458,6 +1605,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with a date of manufacture code illegible or not displayed on any axle (excluding a front steered axle).",
+            "deficiencyTextWelsh": "gyda chod dyddiad gweithgynhyrchu yn annarllenadwy neu heb ei arddangos ar unrhyw echel (ac eithrio echel flaen llywio).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1467,6 +1615,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "with a date of manufacture code illegible or not displayed to any front steered axle of a vehicle.",
+            "deficiencyTextWelsh": "gyda chod dyddiad gweithgynhyrchu yn annarllenadwy neu heb ei arddangos ar unrhyw echel flaen y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -1476,6 +1625,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "in excess of ten years of age fitted to the front steered axle or any axle on a minibus with a single wheel fitment.",
+            "deficiencyTextWelsh": "dros ddeng mlwydd oed wedi'i ffitio ar yr echel flaen y llyw neu unrhyw echel ar fws mini gyda ffitiad olwyn sengl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -1485,6 +1635,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with a date of manufacture code illegible or not displayed (excluding a front steered axle or any axle on a minibus with single wheel fitment).",
+            "deficiencyTextWelsh": "gyda chod dyddiad gweithgynhyrchu yn annarllenadwy neu heb ei arddangos (ac eithrio echel flaen llywio neu unrhyw echel ar fws mini gyda ffitiad olwyn sengl). ",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -1494,6 +1645,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "with a date of manufacture code illegible or not displayed to any front steered axle or any axle on a minibus with single wheel fitment.",
+            "deficiencyTextWelsh": "gyda chod dyddiad gweithgynhyrchu yn annarllenadwy neu heb ei arddangos ar unrhyw echel flaen llywio neu unrhyw echel ar fws mini gyda ffitiad olwyn sengl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -1502,6 +1654,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A recut tyre:",
+        "itemDescriptionWelsh": "Teiar wedi'i ail-dorri:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -1510,6 +1663,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fitted to a vehicle which should not have one.",
+            "deficiencyTextWelsh": "wedi'i osod ar gerbyd na ddylai fod ag un.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1519,6 +1673,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "on which the wholly or partly recut tread pattern is not to the manufacturer’s recut tread pattern.",
+            "deficiencyTextWelsh": "lle nad yw’r patrwm gwadn wedi'i aildorri yn gyfan gwbl neu’n rhannol yn cyfateb i batrwm gwadn aildoriad y gwneuthurwr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -1530,6 +1685,7 @@
     "id": 7,
     "imNumber": 9,
     "imDescription": "Bumper Bars",
+    "imDescriptionWelsh": "Bariau Bymper",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -1551,6 +1707,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A bumper bar or bracket which is:",
+        "itemDescriptionWelsh": "Bar bymper neu fraced sydd:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -1559,6 +1716,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -1568,6 +1726,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to the extent that detachment is imminent.",
+            "deficiencyTextWelsh": "yn ansicr i'r graddau y mae datgysylltiad ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -1577,6 +1736,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has a jagged or projecting edge likely to cause injury.",
+            "deficiencyTextWelsh": "ag ymyl miniog neu bargodol sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -1588,6 +1748,7 @@
     "id": 8,
     "imNumber": 9,
     "imDescription": "Sideguards, Rear Under-Run Devices & Bumper Bars",
+    "imDescriptionWelsh": "Gardiau ochr, Dyfeisiau Tan-Red yn y Cefn a Bariau Bymper",
     "forVehicleType": ["hgv", "trl"],
     "additionalInfo": {
       "hgv": {
@@ -1619,6 +1780,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A bumper bar or bracket which is:",
+        "itemDescriptionWelsh": "Bar bymper neu fraced sydd:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -1627,6 +1789,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1636,6 +1799,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to the extent that detachment is imminent.",
+            "deficiencyTextWelsh": "yn ansicr i'r graddau y mae datgysylltiad ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1645,6 +1809,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has a jagged or projecting edge likely to cause injury.",
+            "deficiencyTextWelsh": "ag ymyl miniog neu bargodol sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -1653,6 +1818,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A sideguard not fitted",
+        "itemDescriptionWelsh": "Giard ochr heb ei osod",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -1661,6 +1827,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "to a vehicle required to have them fitted.",
+            "deficiencyTextWelsh": "i gerbyd sydd ei angen i'w gosod.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -1669,6 +1836,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A sideguard or bracket:",
+        "itemDescriptionWelsh": "Gard ochr neu fraced:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -1677,6 +1845,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1686,6 +1855,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to the extent that detachment is imminent.",
+            "deficiencyTextWelsh": "yn ansicr i'r graddau y mae datgysylltiad ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1695,6 +1865,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cracked, fractured, corroded or damaged so that its effectiveness is reduced.",
+            "deficiencyTextWelsh": "wedi cracio, torri asgwrn, wedi cyrydu neu wedi'i ddifrodi fel bod ei effeithiolrwydd yn cael ei leihau.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1704,6 +1875,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with exposed surfaces which are not smooth (e.g. projecting brackets, jagged edges, bolt heads that are not dome shaped).",
+            "deficiencyTextWelsh": "gydag arwynebau agored nad ydynt yn llyfn (e.e. cromfachau ymestynnol, ymylon miniog, pennau bolltau nad ydynt ar ffurf cromen).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1713,6 +1885,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with external corners or edges that are sharp.",
+            "deficiencyTextWelsh": "gyda chorneli allanol neu ymylon miniog.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1722,6 +1895,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with incorrect dimensions.",
+            "deficiencyTextWelsh": "gyda dimensiynau anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1731,6 +1905,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "that is not continuous along the vehicle length in other than accepted circumstances.",
+            "deficiencyTextWelsh": "nad yw'n barhaus ar hyd hyd y cerbyd ac eithrio amgylchiadau a dderbynnir.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1740,6 +1915,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "that increases the overall width of the vehicle.",
+            "deficiencyTextWelsh": "sy'n cynyddu lled cyffredinol y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1749,6 +1925,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with more than 550mm height from the ground to the lowest edge of the guard. (vehicle unladen or semi-trailer load platform horizontal).",
+            "deficiencyTextWelsh": "gyda mwy na 550mm o uchder o'r ddaear i ymyl isaf y gard. (llwyfan llwyth heb ei lwytho cerbyd neu lled-ôl-gerbyd llorweddol).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -1757,6 +1934,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Rear Under-Run Device",
+        "itemDescriptionWelsh": "Dyfais Dan-redeg Cefn:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -1765,6 +1943,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted to a vehicle required to have one fitted.",
+            "deficiencyTextWelsh": "heb ei osod ar gerbyd mae angen gosod un.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -1773,6 +1952,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Rear Under-Run device:",
+        "itemDescriptionWelsh": "Dyfais Dan-redeg Cefn:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -1781,6 +1961,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1790,6 +1971,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to the extent that detachment is imminent.",
+            "deficiencyTextWelsh": "yn ansicr i'r graddau y mae datgysylltiad ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1799,6 +1981,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cracked, fractured, corroded or damaged so that its effectiveness is reduced.",
+            "deficiencyTextWelsh": "wedi cracio, torri asgwrn, wedi cyrydu neu wedi'i ddifrodi fel bod ei effeithiolrwydd yn cael ei leihau.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1808,6 +1991,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "that has a jagged edge.",
+            "deficiencyTextWelsh": "sydd ag ymyl miniog.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1817,6 +2001,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with more than 550mm ground clearance (unladen).",
+            "deficiencyTextWelsh": "gyda mwy na 550mm o gliriad tir (heb lwyth).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1826,6 +2011,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which extends beyond the outer edge of the outermost rear tyre (see note in proceedure and standards).",
+            "deficiencyTextWelsh": "sy'n ymestyn y tu hwnt i ymyl allanol y teiar cefn mwyaf allanol (gweler y nodyn yn y weithdrefn a'r safonau).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1835,6 +2021,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with the outer end of the device more than 100mm inboard of the outer edge of the outermost rear tyre (or more than 300mm inboard where a demountable body is fitted).",
+            "deficiencyTextWelsh": "gyda phen allanol y dyfais yn fwy na 100mm i mewn i ymyl allanol y teiar cefn mwyaf allanol (neu fwy na 300mm i mewn i fwrdd lle mae corff symudadwy wedi'i osod).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1844,6 +2031,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "extends beyond the outermost width of the vehicle which is fitted with a tail lift.",
+            "deficiencyTextWelsh": "yn ymestyn y tu hwnt i led allanol y cerbyd sydd â lifft ôl.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1853,6 +2041,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete.",
+            "deficiencyTextWelsh": "anghyflawn.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -1864,6 +2053,7 @@
     "id": 9,
     "imNumber": 10,
     "imDescription": "Spare Wheel & Carrier",
+    "imDescriptionWelsh": "Olwyn Sbâr & Chludiwr",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -1907,6 +2097,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A spare wheel:",
+        "itemDescriptionWelsh": "Olwyn sbâr:",
         "forVehicleType": ["hgv", "trl", "psv"],
         "deficiencies": [
           {
@@ -1915,6 +2106,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, damaged or incorrectly positioned but not so that it is likely to fall from the vehicle.",
+            "deficiencyTextWelsh": "yn ansicr, wedi'i ddifrodi neu wedi'i leoli'n anghywir ond nid fel bod y naill na'r llall yn debygol o ddisgyn o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1924,6 +2116,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure or positioned that it is likely to fall from the vehicle.",
+            "deficiencyTextWelsh": "mor anniogel neu mewn safle fel ei fod yn debygol o ddisgyn o'r cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -1933,6 +2126,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure or positioned that it is likely to fall from the vehicle or cause damage to the electrical wiring, other vehicle components or passenger luggage, or is likely to injure occupants.",
+            "deficiencyTextWelsh": "mor anniogel neu mewn safle fel ei fod yn debygol o ddisgyn o'r cerbyd neu achosi difrod i'r gwifrau trydanol, cydrannau eraill y cerbyd neu fagiau teithwyr, neu'n debygol o anafu preswylwyr.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -1941,6 +2135,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A spare wheel carrier:",
+        "itemDescriptionWelsh": "Cludwr olwyn sbâr:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -1949,6 +2144,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "not in proper condition.",
+            "deficiencyTextWelsh": "ddim mewn cyflwr priodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1958,6 +2154,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, damaged or incorrectly positioned but not so that either is likely to fall from the vehicle.",
+            "deficiencyTextWelsh": "yn ansicr, wedi'i ddifrodi neu wedi'i leoli'n anghywir ond nid fel bod y naill na'r llall yn debygol o ddisgyn o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -1967,6 +2164,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure, damaged or positioned that it is likely to fall from the vehicle.",
+            "deficiencyTextWelsh": "mor anniogel, wedi'i ddifrodi neu mewn safle fel ei fod yn debygol o ddisgyn o'r cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -1978,6 +2176,7 @@
     "id": 10,
     "imNumber": 11,
     "imDescription": "Vehicle to Trailer Coupling",
+    "imDescriptionWelsh": "Cyplu Cerbyd i Drelar",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -2021,6 +2220,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A drawing hitch, bar, hook, eye, ball or ball socket; or a fifth wheel king pin and its mounting or a turntable which:",
+        "itemDescriptionWelsh": "Bachyn tynnu, bar, bachyn, llygad, pêl neu soced pêl; neu bin pumed olwyn a'i fowntio neu fwrdd tro sydd:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2029,6 +2229,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "is excessively worn.",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2038,6 +2239,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "is excessively worn with obvious risk of detachment",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol gyda risg amlwg o ddatgysylltu",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2047,6 +2249,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "is seriously deformed or modified impairing its effectiveness and or weakens the component (no trailer attached).",
+            "deficiencyTextWelsh": "wedi cael ei ddadffurfio'n ddifrifol neu wedi'i addasu gan amharu ar ei effeithiolrwydd a neu'n gwanhau'r gydran (dim trelar ynghlwm).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2056,6 +2259,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "is seriously deformed or modified impairing its effectiveness and or weakens the component (trailer attached).",
+            "deficiencyTextWelsh": "wedi cael ei ddadffurfio'n ddifrifol neu wedi'i addasu gan amharu ar ei effeithiolrwydd a neu'n gwanhau'r gydran (trelar ynghlwm).",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2065,6 +2269,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "is cracked or fractured (no trailer attached).",
+            "deficiencyTextWelsh": "wedi cracio neu wedi torri (dim trelar ynghlwm).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2074,6 +2279,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "is cracked or fractured (trailer attached).",
+            "deficiencyTextWelsh": "wedi cracio neu wedi torri (trelar ynghlwm).",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2083,6 +2289,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "is insecure.",
+            "deficiencyTextWelsh": "yn anniogel",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2092,6 +2299,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "is insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "yn ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2101,6 +2309,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "has excessive movement between the vehicle and trailer.",
+            "deficiencyTextWelsh": "mae ganddo symudiad gormodol rhwng y cerbyd a'r trelar.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2110,6 +2319,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has a turntable which has no clearance between mating surfaces, i.e. evidence of contact between the surfaces.",
+            "deficiencyTextWelsh": "â bwrdd tro nad oes ganddo unrhyw gliriad rhwng arwynebau paru, h.y. tystiolaeth o gyswllt rhwng yr arwynebau.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2119,6 +2329,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has a missing, damaged, seized and or inadequate safety or locking device or any coupling indicator inoperative.",
+            "deficiencyTextWelsh": "yn meddu ar ddyfais diogelwch neu gloi ar goll, wedi'i difrodi, wedi'i hatafaelu a/neu'n annigonol neu unrhyw ddangosydd cyplu yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2128,6 +2339,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has a coupling too weak.",
+            "deficiencyTextWelsh": "mae ganddo gyplydd yn rhy wan.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2136,6 +2348,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A Fifth Wheel Coupling with:",
+        "itemDescriptionWelsh": "Pumed Olwyn yn Cyplysu â:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2144,6 +2357,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecurity between the fifth wheel and its mounting subframe and or chassis.",
+            "deficiencyTextWelsh": "ansicrwydd rhwng y bumed olwyn a'i is-ffrâm mowntio a/neu siasi.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2153,6 +2367,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecurity between the fifth wheel and its mounting subframe and or chassis to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "ansicrwydd rhwng y bumed olwyn a'i is-ffrâm mowntio a/neu siasi i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2162,6 +2377,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a mandatory bolt loose or missing.",
+            "deficiencyTextWelsh": "bollt gorfodol yn rhydd neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2171,6 +2387,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "mandatory bolts loose or missing to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "bolltau gorfodol yn rhydd neu ar goll i'r fath raddau fel bod datodiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2180,6 +2397,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "jaws excessively worn or out of adjustment.",
+            "deficiencyTextWelsh": "genau wedi treulio'n ormodol neu allan o addasiad.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2189,6 +2407,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "jaws so worn or out of adjustment that the trailer kingpin would not be securely held.",
+            "deficiencyTextWelsh": "safnau sydd wedi treulio cymaint neu allan o addasiad na fyddai kingpin y trelar yn cael ei gadw'n ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2198,6 +2417,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a safety locking device is missing or inoperative.",
+            "deficiencyTextWelsh": "dyfais cloi diogelwch ar goll neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2207,6 +2427,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "an articulating bracket or pivot excessively worn or insecure.",
+            "deficiencyTextWelsh": "braced cymalog neu golyn wedi treulio'n ormodol neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2216,6 +2437,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "an articulating bracket or pivot excessively worn or insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "braced cymalog neu golyn wedi treulio'n ormodol neu'n ansefydlog i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2225,6 +2447,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any crack in a load bearing member.",
+            "deficiencyTextWelsh": "unrhyw grac mewn aelod sy'n cario llwyth.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2234,6 +2457,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "an operating member insecure or worn to such an extent the coupling is unsafe.",
+            "deficiencyTextWelsh": "aelod gweithredol yn ansicr neu wedi treulio i'r fath raddau y cyplydd yn anniogel.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2242,6 +2466,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Articulated buses - Coupling articulating bracket, operating member or safety device:",
+        "itemDescriptionWelsh": "Bysiau cymalog - Cyplu braced cymalog, aelod gweithredu neu ddyfais ddiogelwch:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -2250,6 +2475,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2259,6 +2485,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2268,6 +2495,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessively worn.",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2277,6 +2505,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessively worn with obvious risk of detachment.",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol gyda risg amlwg o ddatgysylltu",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2286,6 +2515,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "load bearing member cracked or fractured (no trailer attached).",
+            "deficiencyTextWelsh": "aelod cario llwyth wedi cracio neu dorri asgwrn (dim trelar ynghlwm).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2295,6 +2525,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "load bearing member cracked or fractured (trailer attached).",
+            "deficiencyTextWelsh": "aelod cario llwyth wedi cracio neu dorri asgwrn (trelar ynghlwm).",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -2303,6 +2534,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Articulated buses - Bellows:",
+        "itemDescriptionWelsh": "Bysiau cymalog - Megin:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -2311,6 +2543,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2320,6 +2553,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2329,6 +2563,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so damaged or deteriorated that injury to passengers or other persons is likely.",
+            "deficiencyTextWelsh": "difrodi neu waethygu cymaint fel bod anaf i deithwyr neu bobl eraill yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -2337,6 +2572,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Articulated buses - Turntable floor:",
+        "itemDescriptionWelsh": "Bysiau cymalog - Llawr bwrdd tro:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -2345,6 +2581,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2354,6 +2591,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2363,6 +2601,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "covering in such a condition that it could cause slipping or tripping.",
+            "deficiencyTextWelsh": "gorchuddio yn y fath gyflwr fel y gallai achosi llithro neu faglu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -2371,6 +2610,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Buses fitted with a trailer coupling - A drawing hitch, bar, hook, eye, ball or ball socket:",
+        "itemDescriptionWelsh": "Bysiau gyda chyplydd trelar wedi’u gosod arnynt - Bachyn tynnu, bar, bachyn, llygad, pêl neu soced pêl:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -2379,6 +2619,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessively worn.",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2388,6 +2629,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessively worn with obvious risk of detachment.",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol gyda risg amlwg o ddatgysylltu",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2397,6 +2639,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "seriously deformed or modified impairing its effectiveness and or weakens the component (no trailer attcahed).",
+            "deficiencyTextWelsh": "wedi'i ddadffurfio'n ddifrifol neu wedi'i addasu gan amharu ar ei effeithiolrwydd a/neu'n gwanhau'r gydran (dim trelar ynghlwm).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2406,6 +2649,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "seriously deformed or modified impairing its effectiveness and or weakens the component (trailer attcahed).",
+            "deficiencyTextWelsh": "wedi'i ddadffurfio'n ddifrifol neu wedi'i addasu gan amharu ar ei effeithiolrwydd a/neu'n gwanhau'r gydran (trelar ynghlwm).",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2415,6 +2659,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "cracked or fractured (no trailer attached).",
+            "deficiencyTextWelsh": "wedi cracio neu wedi torri (dim trelar ynghlwm).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2424,6 +2669,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cracked or fractured (trailer attached).",
+            "deficiencyTextWelsh": "wedi cracio neu wedi torri (trelar ynghlwm).",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2433,6 +2679,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2442,6 +2689,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "is insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "yn ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -2451,6 +2699,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has a missing, damaged, inoperative and or inadequate safety or locking device or any coupling indicator inoperative.",
+            "deficiencyTextWelsh": "sydd â dyfais diogelwch neu gloi ar goll, wedi'i difrodi, anweithredol a/neu annigonol neu unrhyw ddangosydd cyplu anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -2459,6 +2708,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Any mechanical coupling or towing device with:",
+        "itemDescriptionWelsh": "Unrhyw ddyfais gyplu neu dynnu mecanyddol gyda:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -2467,6 +2717,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "an unsafe modification to it secondary parts.",
+            "deficiencyTextWelsh": "addasiad anniogel i'w rhannau eilaidd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2476,6 +2727,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "an unsafe modification to it primary parts.",
+            "deficiencyTextWelsh": "addasiad anniogel i'w rhannau sylfaenol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -2487,6 +2739,7 @@
     "id": 11,
     "imNumber": 12,
     "imDescription": "Trailer Parking and Emergency Brakes and Air Line Connections",
+    "imDescriptionWelsh": "Parcio Trelars a Breciau Argyfwng a Chysylltiadau Llinell Awyr",
     "forVehicleType": ["trl", "hgv"],
     "additionalInfo": {
       "psv": {},
@@ -2519,6 +2772,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Trailer parking brake:",
+        "itemDescriptionWelsh": "Brêc parcio trelar:",
         "forVehicleType": ["trl"],
         "deficiencies": [
           {
@@ -2527,6 +2781,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "does not operate on at least two wheels.",
+            "deficiencyTextWelsh": "nad yw'n gweithredu ar o leiaf dwy olwyn.",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           },
@@ -2536,6 +2791,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cannot be securely set.",
+            "deficiencyTextWelsh": "ni ellir ei osod yn ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           },
@@ -2545,6 +2801,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "mechanism worn.",
+            "deficiencyTextWelsh": "mecanwaith wedi treulio.",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           },
@@ -2554,6 +2811,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "mechanism insecure, cracked, excessively worn or badly corroded.",
+            "deficiencyTextWelsh": "mecanwaith yn ansicr, wedi cracio, wedi treulio'n ormodol neu wedi cyrydu'n wael.",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           },
@@ -2563,6 +2821,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "when fully applied the mechanism is at the end of its working travel or it is fouling adjacent parts of the vehicle.",
+            "deficiencyTextWelsh": "pan gaiff ei gymhwyso'n llawn mae'r mecanwaith ar ddiwedd ei deithio gwaith neu mae'n baeddu rhannau cyfagos o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           }
@@ -2571,6 +2830,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Trailer emergency brake",
+        "itemDescriptionWelsh": "Brêc argyfwng trelar",
         "forVehicleType": ["trl"],
         "deficiencies": [
           {
@@ -2579,6 +2839,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "not applied automatically when the emergency brake line is disconnected.",
+            "deficiencyTextWelsh": "heb ei gymhwyso'n awtomatig pan fydd y llinell brêc brys wedi'i datgysylltu.",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           }
@@ -2587,6 +2848,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Operating adaptor, to open self sealing coupling in service line:",
+        "itemDescriptionWelsh": "Addasydd gweithredu, i agor cyplydd hunan-selio yn y llinell wasanaeth:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2595,6 +2857,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted in service line.",
+            "deficiencyTextWelsh": "heb ei ffitio yn y llinell wasanaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2604,6 +2867,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "produces incorrect amount of lift.",
+            "deficiencyTextWelsh": "yn cynhyrchu swm anghywir o lifft.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2612,6 +2876,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "An airline",
+        "itemDescriptionWelsh": "Cwmni hedfan",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2620,6 +2885,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fitted with a manual shut off tap.",
+            "deficiencyTextWelsh": "wedi'i ffitio â thap diffodd â llaw.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2628,6 +2894,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Tap or sealing valve",
+        "itemDescriptionWelsh": "Tap neu falf selio",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2636,6 +2903,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure, inadequately mounted or defective.",
+            "deficiencyTextWelsh": "ansefydlog, wedi'i osod yn annigonol neu'n ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2645,6 +2913,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, inadequately mounted or defective to such an extent the functionality is affected.",
+            "deficiencyTextWelsh": "ansefydlog, wedi'i osod yn annigonol neu'n ddiffygiol i'r fath raddau yr effeithir ar y swyddogaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2656,6 +2925,7 @@
     "id": 12,
     "imNumber": 13,
     "imDescription": "Trailer Landing Legs",
+    "imDescriptionWelsh": "Coesau Glanio Trelar",
     "forVehicleType": ["trl"],
     "additionalInfo": {
       "psv": {},
@@ -2688,6 +2958,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A landing leg or any component part",
+        "itemDescriptionWelsh": "Coes lanio neu unrhyw gydran",
         "forVehicleType": ["trl"],
         "deficiencies": [
           {
@@ -2696,6 +2967,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure that it is likely to fall from the vehicle.",
+            "deficiencyTextWelsh": "mor anniogel fel ei fod yn debygol o ddisgyn o'r cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["trl"]
           }
@@ -2707,6 +2979,7 @@
     "id": 13,
     "imNumber": 14,
     "imDescription": "Spray Suppression, Wings and Wheel Arches",
+    "imDescriptionWelsh": "Ataliad Chwistrellu, Adenydd a Bwaau Olwyn",
     "forVehicleType": ["hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -2750,6 +3023,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A Wing or Wheel Arch:",
+        "itemDescriptionWelsh": "Adain neu Bwa Olwyn:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2758,6 +3032,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "missing or so badly corroded or distorted to stop it acting as an adequate shield or in the case of a mud flap fitted as a wing, it is not restrained or constructed to stop wind lift.",
+            "deficiencyTextWelsh": "ar goll neu wedi cyrydu mor ddrwg neu wedi'i ystumio i'w atal rhag gweithredu fel tarian ddigonol neu yn achos fflap mwd wedi'i osod fel adain, nid yw wedi'i atal nac wedi'i adeiladu i atal lifft gwynt.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2767,6 +3042,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "so badly corroded or distorted or so insecure that it can fall off or rub on the tyre.",
+            "deficiencyTextWelsh": "wedi cyrydu neu ystumio mor ddrwg neu mor ansefydlog fel y gall ddisgyn i ffwrdd neu rwbio ar y teiar.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2776,6 +3052,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "that has sharp edges that are likely to cause injury.",
+            "deficiencyTextWelsh": "sydd ag ymylon miniog sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2785,6 +3062,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which is rubbing on a tyre.",
+            "deficiencyTextWelsh": "sy'n rhwbio ar deiar.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2794,6 +3072,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which does not cover the whole width of a tyre when the wheel is in the straight ahead position.",
+            "deficiencyTextWelsh": "nad yw'n gorchuddio lled cyfan teiar pan fod yr olwyn yn y safle syth ymlaen.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2802,6 +3081,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Spray Suppression:",
+        "itemDescriptionWelsh": "Atal Chwistrell:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -2810,6 +3090,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure to such an extent it is likely to drop off.",
+            "deficiencyTextWelsh": "ansicr i'r fath raddau fel ei fod yn debygol o ollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2819,6 +3100,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted where required.",
+            "deficiencyTextWelsh": "heb eu gosod lle bod angen.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2828,6 +3110,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete or seriously defective.",
+            "deficiencyTextWelsh": "anghyflawn neu'n ddifrifol ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2837,6 +3120,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "dimensions do not comply with requirements.",
+            "deficiencyTextWelsh": "nid yw'r dimensiynau'n cydymffurfio â'r gofynion.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2846,6 +3130,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a wheel flap not restrained or stiff enough to stop excessive movement or wind lift in normal use.",
+            "deficiencyTextWelsh": "gyda fflap olwyn heb ei atal neu'n ddigon anystwyth i atal symudiad gormodol neu wynt codi yn y defnydd arferol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -2855,6 +3140,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with more than 25% of the minimum required wheel flap or spray suppression material area clogged with mud or debris.",
+            "deficiencyTextWelsh": "gyda mwy na 25% o'r lleiafswm fflap olwyn gofynnol neu arwynebedd deunydd atal chwistrell wedi'i rwystro gan fwd neu falurion.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -2866,6 +3152,7 @@
     "id": 14,
     "imNumber": 14,
     "imDescription": "Wings and Wheel Arches",
+    "imDescriptionWelsh": "Adenydd a Bwâu Olwyn",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -2887,6 +3174,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A Wing or Wheel Arch:",
+        "itemDescriptionWelsh": "Adain neu Bwa Olwyn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -2895,6 +3183,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "missing or so badly corroded or distorted to stop it acting as an adequate shield.",
+            "deficiencyTextWelsh": "ar goll neu wedi cyrydu mor ddrwg neu wedi ei ystumio i'w atal rhag gweithredu fel tarian ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2904,6 +3193,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "so badly corroded or distorted or so insecure that it can fall off or rub on the tyre.",
+            "deficiencyTextWelsh": "wedi cyrydu neu ystumio mor ddrwg neu mor ansefydlog fel y gall ddisgyn i ffwrdd neu rwbio ar y teiar.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2913,6 +3203,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "that has sharp edges that are likely to cause injury.",
+            "deficiencyTextWelsh": "sydd ag ymylon miniog sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2922,6 +3213,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which is rubbing on a tyre.",
+            "deficiencyTextWelsh": "sy'n rhwbio ar deiar.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -2931,6 +3223,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which does not cover the whole width of a tyre when the wheel is in the straight ahead position.",
+            "deficiencyTextWelsh": "nad yw'n gorchuddio lled cyfan teiar pan fod yr olwyn yn y safle syth ymlaen.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -2942,6 +3235,7 @@
     "id": 15,
     "imNumber": 15,
     "imDescription": "Cab Security",
+    "imDescriptionWelsh": "Diogelwch Cab",
     "forVehicleType": ["hgv"],
     "additionalInfo": {
       "psv": {},
@@ -2963,6 +3257,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A Cab:",
+        "itemDescriptionWelsh": "Cab:",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -2971,6 +3266,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure but not affecting the stability of the vehicle.",
+            "deficiencyTextWelsh": "anniogel ond heb effeithio ar sefydlogrwydd y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -2980,6 +3276,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with any insecurity that is likely to affect the stability of the vehicle.",
+            "deficiencyTextWelsh": "gydag unrhyw ansicrwydd sy'n debygol o effeithio ar sefydlogrwydd y cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv"]
           },
@@ -2989,6 +3286,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "retention and/or locking device on a tilt cab missing or defective.",
+            "deficiencyTextWelsh": "dyfais cadw a/neu gloi ar gab gogwyddo ar goll neu'n ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -2998,6 +3296,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "retention and/or locking device on a tilt cab missing and or defective to such an extent that it seriously effects road safety.",
+            "deficiencyTextWelsh": "dyfais cadw a/neu gloi ar gaban gogwyddo sydd ar goll neu'n ddiffygiol i'r fath raddau fel ei fod yn effeithio'n ddifrifol ar ddiogelwch ar y ffyrdd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3007,6 +3306,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "obviously not located squarely on chassis and which obviously affects safe control of the vehicle.",
+            "deficiencyTextWelsh": "yn amlwg heb ei leoli'n sgwâr ar siasi ac sy'n amlwg yn effeithio ar reolaeth ddiogel y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3016,6 +3316,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with excessive corrosion or damage to a load bearing member which seriously reduces its strength within 30cm of the cab mountings.",
+            "deficiencyTextWelsh": "gyda chorydiad gormodol neu ddifrod i aelod sy'n cario llwyth sy'n lleihau ei gryfder yn ddifrifol o fewn 30cm i osodiadau'r cab.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3025,6 +3326,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with excessive corrosion or damage to a load bearing member which seriously reduces its strength within 30cm of the cab mountings and stability is obviously affected.",
+            "deficiencyTextWelsh": "gyda chorydiad gormodol neu ddifrod i aelod sy'n cario llwyth sy'n lleihau ei gryfder yn ddifrifol o fewn 30cm i osodiadau'r cab ac mae'n amlwg bod sefydlogrwydd yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -3036,6 +3338,7 @@
     "id": 16,
     "imNumber": 16,
     "imDescription": "Cab Doors",
+    "imDescriptionWelsh": "Drysau Cab",
     "forVehicleType": ["hgv"],
     "additionalInfo": {
       "psv": {
@@ -3068,6 +3371,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A Door which:",
+        "itemDescriptionWelsh": "Drws sydd:",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -3076,6 +3380,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3085,6 +3390,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be opened.",
+            "deficiencyTextWelsh": "methu cael ei agor.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3094,6 +3400,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "has a sliding action and it will not remain closed or is likely to fly open inadvertently.",
+            "deficiencyTextWelsh": "â gweithred llithro ac na fydd yn parhau ar gau neu sy'n debygol o hedfan ar agor yn anfwriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3103,6 +3410,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "has a hinged action and it will not remain closed or is likely to fly open inadvertently.",
+            "deficiencyTextWelsh": "â cholfach arno ac na fydd yn aros ar gau neu sy'n debygol o hedfan ar agor yn anfwriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -3114,6 +3422,7 @@
     "id": 17,
     "imNumber": 16,
     "imDescription": "Passenger Doors, Driver Doors and Emergency Exits",
+    "imDescriptionWelsh": "Drysau Teithwyr, Drysau Gyrwyr ac Allanfeydd Argyfwng",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -3135,6 +3444,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A door or emergency exit:",
+        "itemDescriptionWelsh": "Drws neu allanfa frys:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3143,6 +3453,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete or missing.",
+            "deficiencyTextWelsh": "anghyflawn neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3152,6 +3463,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be opened to its fullest extent.",
+            "deficiencyTextWelsh": "methu cael ei agor i'w eithaf. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3161,6 +3473,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with a sliding action which will not remain closed or is likely to fly open inadvertently or will not open without undue effort.",
+            "deficiencyTextWelsh": "gyda gweithred llithro na fydd yn aros ar gau neu sy'n debygol o hedfan ar agor yn anfwriadol neu na fydd yn agor heb ymdrech ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3170,6 +3483,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with a hinged action which will not remain closed or is likely to fly open inadvertently.",
+            "deficiencyTextWelsh": "gyda gweithred golfach na fydd yn aros ar gau neu sy'n debygol o hedfan ar agor yn anfwriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3179,6 +3493,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a missing/defective device for holding a door, or on a Bus Directive or ECE vehicle, a door or top hinged emergency window, open.",
+            "deficiencyTextWelsh": "gyda dyfais ar goll/diffygiol ar gyfer dal drws, neu ar Gyfarwyddeb Bws neu gerbyd ECE, drws neu ffenestr argyfwng colfachog uchaf, ar agor.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3188,6 +3503,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with insecure, excessively worn or fractured hinges or pins or insecure door pillars which could adversely affect operation.",
+            "deficiencyTextWelsh": "gyda cholfachau neu binnau ansefydlog, wedi treulio'n ormodol neu wedi torri neu bileri drws ansicr a allai effeithio'n andwyol ar weithrediad.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3197,6 +3513,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "with insecure, excessively worn or fractured hinges or pins or insecure door pillars which could adversely affect operation and is likely to cause an injury.",
+            "deficiencyTextWelsh": "gyda cholfachau neu binnau ansefydlog, wedi treulio'n ormodol neu wedi torri neu bileri drws ansicr a allai effeithio'n andwyol ar weithrediad ac sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3206,6 +3523,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a supplementary locking device which cannot be overridden by all the associated interior door controls.",
+            "deficiencyTextWelsh": "gyda dyfais gloi atodol na ellir ei ddiystyru gan yr holl reolaethau drws mewnol cysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3215,6 +3533,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a release handle guard insecure or missing.",
+            "deficiencyTextWelsh": "gyda gard handlen rhyddhau yn ansefydlog neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3224,6 +3543,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "“open” warning device missing or inoperative.",
+            "deficiencyTextWelsh": "dyfais rhybuddio “ar agor” ar goll neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3233,6 +3553,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a break glass window fitted with laminated glass or other unbreakable glazing.",
+            "deficiencyTextWelsh": "ffenestr dorri gwydr gyda gwydr wedi'i lamineiddio neu wydr arall na ellir ei dorri.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3241,6 +3562,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A door or emergency exit opening or closing mechanism:",
+        "itemDescriptionWelsh": "Mecanwaith agor neu gau drws neu allanfa frys:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3249,6 +3571,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "defective, excessively worn or damaged so that it is difficult to open or close the door or exit.",
+            "deficiencyTextWelsh": "diffygiol, wedi treulio'n ormodol neu wedi'i ddifrodi fel ei fod yn anodd agor neu gau'r drws neu'r allanfa.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3258,6 +3581,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "control button(s) loose, sticking or with excessive movement before operating.",
+            "deficiencyTextWelsh": "botwm(au) rheoli yn rhydd, yn glynu neu'n symud yn ormodol cyn gweithredu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3266,6 +3590,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A door and emergency exit marking:",
+        "itemDescriptionWelsh": "Marcio drws ac allanfa frys:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3274,6 +3599,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3283,6 +3609,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "method of operation not shown (not applicable to Schedule 6 apart from the emergency door).",
+            "deficiencyTextWelsh": "dull gweithredu heb ei ddangos (ddim yn berthnasol i Atodlen 6 ac eithrio'r drws argyfwng).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3291,6 +3618,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Power operated doors and emergency exits:",
+        "itemDescriptionWelsh": "Drysau pŵer ac allanfeydd brys:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3299,6 +3627,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "repeated operations of the doors depletes the braking system(s) pressure below the level at which the circuit protection valve should operate.",
+            "deficiencyTextWelsh": "mae gweithredu'r drysau dro ar ôl tro yn disbyddu pwysedd y system(au) brecio islaw'r lefel y dylai'r falf amddiffyn cylched weithredu arni.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3308,6 +3637,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be opened from inside or outside the vehicle using the emergency controls.",
+            "deficiencyTextWelsh": "ni ellir eu hagor o'r tu mewn neu'r tu allan i'r cerbyd gan ddefnyddio'r rheolyddion brys.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3317,6 +3647,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "soft edge missing, deteriorated or damaged so that injury could be caused to any person.",
+            "deficiencyTextWelsh": "ymyl meddal ar goll, wedi dirywio neu wedi'i ddifrodi fel y gellir achosi anaf i unrhyw berson.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3326,6 +3657,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "safety system does not operate correctly.",
+            "deficiencyTextWelsh": "nid yw'r system ddiogelwch yn gweithredu'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3334,6 +3666,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Plug door",
+        "itemDescriptionWelsh": "Drws plwg",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3342,6 +3675,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "opens or closes suddenly or with excessive force and is likely to injure persons outside the vehicle.",
+            "deficiencyTextWelsh": "yn agor neu'n cau'n sydyn neu gyda gormod o rym ac yn debygol o anafu pobl y tu allan i'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3350,6 +3684,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Emergency exits",
+        "itemDescriptionWelsh": "Allanfeydd brys",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3358,6 +3693,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with an opening tool or device missing or not secured in a readily accessible place.",
+            "deficiencyTextWelsh": "gydag offeryn neu ddyfais agoriadol ar goll neu heb ei ddiogelu mewn man hygyrch.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3366,6 +3702,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "Driver cannot activate or deactivate",
+        "itemDescriptionWelsh": "Ni all gyrrwr actifadu neu ddadactifadu",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3374,6 +3711,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the operation of an automatically operated service door.",
+            "deficiencyTextWelsh": "gweithrediad drws gwasanaeth a weithredir yn awtomatig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3385,6 +3723,7 @@
     "id": 18,
     "imNumber": 17,
     "imDescription": "Cab Floor and Steps",
+    "imDescriptionWelsh": "Llawr Cab a Grisiau",
     "forVehicleType": ["hgv"],
     "additionalInfo": {
       "psv": {
@@ -3417,6 +3756,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A cab floor or internal wheel arch:",
+        "itemDescriptionWelsh": "Llawr cab neu fwa olwyn fewnol:",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -3425,6 +3765,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "which is badly deteriorated or insecure.",
+            "deficiencyTextWelsh": "sydd wedi dirywio'n wael neu'n ansicr.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3434,6 +3775,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "which is so badly deteriorated or insecure it is likely to impair the driver’s control of the vehicle or is likely to cause injury.",
+            "deficiencyTextWelsh": "sydd wedi dirywio mor ddrwg neu mor ansicr fel ei fod yn debygol o amharu ar reolaeth y gyrrwr o’r cerbyd neu’n debygol o achosi anaf.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv"]
           }
@@ -3442,6 +3784,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Any step or step ring:",
+        "itemDescriptionWelsh": "Unrhyw gylch cam neu gam:",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -3450,6 +3793,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3459,6 +3803,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "so insecure or in such a condition it is likely to cause injury.",
+            "deficiencyTextWelsh": "mor ansicr neu mewn cyflwr o'r fath mae'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -3470,12 +3815,14 @@
     "id": 19,
     "imNumber": 17,
     "imDescription": "Drivers Accommodation",
+    "imDescriptionWelsh": "Llety Gyrwyr",
     "forVehicleType": ["psv"],
     "additionalInfo": null,
     "items": [
       {
         "itemNumber": 1,
         "itemDescription": "A cab floor or internal wheel arch in the driver's area which:",
+        "itemDescriptionWelsh": "Llawr cab neu fwa olwyn mewnol yn ardal y gyrrwr sydd:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3484,6 +3831,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "is badly deteriorated or insecure.",
+            "deficiencyTextWelsh": "wedi dirywio'n wael neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3493,6 +3841,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "is so badly deteriorated or insecure it is likely to impair the driver's control of the vehicle or is likely to cause injury..",
+            "deficiencyTextWelsh": "wedi dirywio mor ddrwg neu mor ansicr fel ei fod yn debygol o amharu ar reolaeth y gyrrwr o’r cerbyd neu’n debygol o achosi anaf..",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -3501,6 +3850,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Step, step ring or grab handle:",
+        "itemDescriptionWelsh": "Cam, cylch cam neu handlen cydio:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3509,6 +3859,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3518,6 +3869,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "which is so insecure or in such a condition it is likely to cause injury.",
+            "deficiencyTextWelsh": "sydd mor ansicr neu mewn cyflwr o'r fath mae'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3526,6 +3878,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Driver's escape window:",
+        "itemDescriptionWelsh": "Ffenestr dianc y gyrrwr:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3534,6 +3887,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not provided.",
+            "deficiencyTextWelsh": "heb ei ddarparu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3543,6 +3897,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be opened.",
+            "deficiencyTextWelsh": "methu cael ei agor.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3554,6 +3909,7 @@
     "id": 20,
     "imNumber": 18,
     "imDescription": "Driver’s Seat",
+    "imDescriptionWelsh": "Sedd Gyrrwr",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -3575,6 +3931,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A driver’s seat:",
+        "itemDescriptionWelsh": "Sedd gyrrwr:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3583,6 +3940,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "structure defective.",
+            "deficiencyTextWelsh": "strwythur yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3592,6 +3950,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure or in such a condition that it could cause the driver to lose control of the vehicle.",
+            "deficiencyTextWelsh": "mor anniogel neu mewn cyflwr o'r fath y gallai achosi i'r gyrrwr golli rheolaeth ar y cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -3600,6 +3959,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "The driver’s seat",
+        "itemDescriptionWelsh": "Sedd y gyrrwr",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3608,6 +3968,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fore and aft adjustment mechanism not functioning as intended.",
+            "deficiencyTextWelsh": "mecanwaith addasu blaen ac ôl ddim yn gweithredu fel y bwriadwyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3619,6 +3980,7 @@
     "id": 21,
     "imNumber": 18,
     "imDescription": "Seats",
+    "imDescriptionWelsh": "Seddi",
     "forVehicleType": ["hgv"],
     "additionalInfo": {
       "psv": {},
@@ -3640,6 +4002,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A driver’s seat:",
+        "itemDescriptionWelsh": "Sedd gyrrwr:",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -3648,6 +4011,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "structure defective.",
+            "deficiencyTextWelsh": "strwythur yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -3657,6 +4021,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure or in such a condition that it could cause the driver to lose control of the vehicle.",
+            "deficiencyTextWelsh": "mor anniogel neu mewn cyflwr o'r fath y gallai achosi i'r gyrrwr golli rheolaeth ar y cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv"]
           },
@@ -3666,6 +4031,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fore and aft adjustment mechanism not functioning as intended.",
+            "deficiencyTextWelsh": "mecanwaith addasu blaen ac ôl ddim yn gweithredu fel y bwriadwyd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -3674,6 +4040,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A passenger seat",
+        "itemDescriptionWelsh": "Sedd teithiwr",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -3682,6 +4049,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure or a backrest that cannot be secured in the upright position.",
+            "deficiencyTextWelsh": "ansefydlog neu gynhalydd cefn na ellir ei sicrhau yn y safle unionsyth.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -3693,6 +4061,7 @@
     "id": 22,
     "imNumber": 19,
     "imDescription": "Security of Body",
+    "imDescriptionWelsh": "Diogelwch y Corff",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -3714,6 +4083,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Body:",
+        "itemDescriptionWelsh": "Corff:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3722,6 +4092,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "excessively displaced relative to the chassis.",
+            "deficiencyTextWelsh": "wedi'i ddadleoli'n ormodol o'i gymharu â'r siasi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3731,6 +4102,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3740,6 +4112,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure with stability affected.",
+            "deficiencyTextWelsh": "anniogel gyda sefydlogrwydd wedi'i effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3748,6 +4121,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A load bearing member so cracked, corroded or damaged that the body is:",
+        "itemDescriptionWelsh": "Aelod sy'n cynnal llwyth wedi cracio, wedi cyrydu neu wedi'i ddifrodi cymaint fel bod y corff:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -3756,6 +4130,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "seriously weakened.",
+            "deficiencyTextWelsh": "wedi'i wanhau'n ddifrifol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -3765,6 +4140,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "seriously weakened and vehicle stability is impaired.",
+            "deficiencyTextWelsh": "wedi'i wanhau'n ddifrifol ac mae sefydlogrwydd y cerbyd wedi'i amharu. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -3776,6 +4152,7 @@
     "id": 23,
     "imNumber": 19,
     "imDescription": "Security of Body, Containers and Crane Support Legs",
+    "imDescriptionWelsh": "Diogelwch Corff, Cynhwysyddion a Choesau Cynnal Craen",
     "forVehicleType": ["hgv", "trl"],
     "additionalInfo": {
       "psv": {},
@@ -3808,6 +4185,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Body:",
+        "itemDescriptionWelsh": "Corff:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -3816,6 +4194,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "excessively displaced relative to the chassis.",
+            "deficiencyTextWelsh": "wedi'i ddadleoli'n ormodol o'i gymharu â'r siasi.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3825,6 +4204,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3834,6 +4214,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure with stability affected.",
+            "deficiencyTextWelsh": "anniogel gyda sefydlogrwydd wedi'i effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -3842,6 +4223,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A load bearing member so cracked, corroded or damaged that the body is:",
+        "itemDescriptionWelsh": "Aelod sy'n cynnal llwyth wedi cracio, wedi cyrydu neu wedi'i ddifrodi cymaint fel bod y corff:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -3850,6 +4232,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "seriously weakend.",
+            "deficiencyTextWelsh": "wedi'i wanhau'n ddifrifol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3859,6 +4242,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "seriously weakend and vehicle/trailer stability is impaired.",
+            "deficiencyTextWelsh": "wedi'i wanhau'n ddifrifol a bod sefydlogrwydd y cerbyd/trelar wedi'i amharu.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -3867,6 +4251,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A container fastening device:",
+        "itemDescriptionWelsh": "Dyfais cau cynhwysydd:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -3875,6 +4260,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing when another of a matched pair is present.",
+            "deficiencyTextWelsh": "ar goll pan fydd un arall o bâr cyfatebol yn bresennol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3884,6 +4270,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "likely to become detached.",
+            "deficiencyTextWelsh": "yn debygol o ddod yn ddatgysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3893,6 +4280,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete.",
+            "deficiencyTextWelsh": "anghyflawn.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3902,6 +4290,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "seized.",
+            "deficiencyTextWelsh": "atafaelu.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3911,6 +4300,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted with an effective secondary locking device.",
+            "deficiencyTextWelsh": "heb ei ffitio â dyfais cloi eilaidd effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3920,6 +4310,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "in such a condition that a container is unlikely to be secured by it.",
+            "deficiencyTextWelsh": "mewn cyflwr o'r fath fel nad yw cynhwysydd yn debygol o gael ei ddiogelu ganddo.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -3928,6 +4319,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "A support bolster or structure:",
+        "itemDescriptionWelsh": "Ategiad neu strwythur cymorth:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -3936,6 +4328,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure, cracked, corroded or damaged such that a container is unlikely to be supported and secured by it.",
+            "deficiencyTextWelsh": "yn anniogel, wedi cracio, wedi cyrydu neu wedi'i ddifrodi fel nad yw cynhwysydd yn debygol o gael ei gynnal a'i ddiogelu ganddo.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3945,6 +4338,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted with locking pins or other securing method incorporating an effective secondary locking device.",
+            "deficiencyTextWelsh": "heb ei osod â phinnau cloi neu ddull diogelu arall sy'n cynnwys dyfais cloi eilaidd effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -3953,6 +4347,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "A Crane Support Legs:",
+        "itemDescriptionWelsh": "Coesau Cefnogi Craen:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -3961,6 +4356,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -3970,6 +4366,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "retaining device missing, insecure or in a condition that it would not adequately retain the leg.",
+            "deficiencyTextWelsh": "dyfais cadw ar goll, yn ansefydlog neu mewn cyflwr na fyddai'n cadw'r goes yn ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -3981,6 +4378,7 @@
     "id": 24,
     "imNumber": 20,
     "imDescription": "Condition of Body",
+    "imDescriptionWelsh": "Cyflwr y Corff",
     "forVehicleType": ["hgv", "trl"],
     "additionalInfo": {
       "psv": {},
@@ -4013,6 +4411,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any headboard, rave, cross or longitudinal member, hinge or retaining device, tipping gear, glass panel or any part of the body designed to carry or contain the load (including the floor and main support pillars):",
+        "itemDescriptionWelsh": "Unrhyw ben gwely, rêf, croes neu aelod hydredol, colfach neu ddyfais gadw, offer tipio, panel gwydr neu unrhyw ran o'r corff sydd wedi'i gynllunio i gario neu ddal y llwyth (gan gynnwys y llawr a'r prif bileri cynnal):",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -4021,6 +4420,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, fractured or cracked, distorted, worn, corroded, damaged or modified, to such an extent it is likely to cause injury.",
+            "deficiencyTextWelsh": "yn ansefydlog, wedi torri neu wedi cracio, wedi ystumio, wedi treulio, wedi cyrydu, wedi'i ddifrodi neu wedi'i addasu, i'r fath raddau ei fod yn debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -4030,6 +4430,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure, fractured or cracked, distorted, worn, corroded, damaged or modified to such an extent the vehicle is obviously dangerous to other road users, passengers or pedestrians.",
+            "deficiencyTextWelsh": "bod y cerbyd yn anniogel, wedi torri neu wedi cracio, wedi ystumio, wedi treulio, wedi cyrydu, wedi ei ddifrodi neu wedi ei addasu i’r fath raddau, yn amlwg yn beryglus i ddefnyddwyr eraill y ffordd, teithwyr neu gerddwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -4039,6 +4440,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with an inappropriate modification of the bodywork.",
+            "deficiencyTextWelsh": "gydag addasiad amhriodol o'r corff.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -4048,6 +4450,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with an unsafe modification of the bodywork which has seriously weakened the component.",
+            "deficiencyTextWelsh": "gydag addasiad anniogel o'r corff sydd wedi gwanhau'r gydran yn ddifrifol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -4056,6 +4459,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A leak from the load carrying compartment",
+        "itemDescriptionWelsh": "Gollyngiad o'r adran cludo llwythi",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -4064,6 +4468,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "which poses a risk to other road users.",
+            "deficiencyTextWelsh": "sy'n peri risg i ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -4073,6 +4478,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "which poses a very serious risk to other road users.",
+            "deficiencyTextWelsh": "sy'n peri risg difrifol iawn i ddefnyddwyr eraill y ffordd. ",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -4081,6 +4487,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A wind deflector or other accessory",
+        "itemDescriptionWelsh": "Alltudiwr gwynt neu affeithiwr arall",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -4089,6 +4496,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so obviously insecure that it is likely to become detached.",
+            "deficiencyTextWelsh": "mor amlwg yn ansefydlog ei fod yn debygol o ddatgysylltiedig.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -4100,6 +4508,7 @@
     "id": 25,
     "imNumber": 20,
     "imDescription": "Exterior of Body including Luggage Compartments",
+    "imDescriptionWelsh": "Tu Allan i'r Corff gan gynnwys Adrannau Bagiau",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -4121,6 +4530,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Body panels, frame members, fittings or components:",
+        "itemDescriptionWelsh": "Paneli corff, aelodau ffrâm, ffitiadau neu gydrannau:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4129,6 +4539,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, fractured or cracked, distorted, worn, corroded, damaged or modified, to such an extent it is likely to cause injury.",
+            "deficiencyTextWelsh": "yn ansefydlog, wedi torri neu wedi cracio, wedi ystumio, wedi treulio, wedi cyrydu, wedi'i ddifrodi neu wedi'i addasu, i'r fath raddau ei fod yn debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4138,6 +4549,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure, fractured or cracked, distorted, worn, corroded, damaged or modified to such an extent the vehicle is obviously dangerous to other road users, passengers or pedestrians.",
+            "deficiencyTextWelsh": "bod y cerbyd yn anniogel, wedi torri neu wedi cracio, wedi ystumio, wedi treulio, wedi cyrydu, wedi ei ddifrodi neu wedi ei addasu i’r fath raddau, yn amlwg yn beryglus i ddefnyddwyr eraill y ffordd, teithwyr neu gerddwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4147,6 +4559,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with an inappropriate modification of the bodywork.",
+            "deficiencyTextWelsh": "gydag addasiad amhriodol o'r corff.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4156,6 +4569,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with an unsafe modification of the bodywork which has seriously weakened the component.",
+            "deficiencyTextWelsh": "gydag addasiad anniogel o'r corff sydd wedi gwanhau'r gydran yn ddifrifol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4164,6 +4578,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Luggage compartment:",
+        "itemDescriptionWelsh": "Adran bagiau:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4172,6 +4587,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "structure defective allowing contents to protrude or fall onto a road, or in a condition to damage or soil luggage.",
+            "deficiencyTextWelsh": "strwythur diffygiol sy'n caniatáu i'r cynnwys ymwthio allan neu ddisgyn ar ffordd, neu mewn cyflwr i ddifrodi neu bridd bagiau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4181,6 +4597,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "access doors likely to become detached.",
+            "deficiencyTextWelsh": "drysau mynediad yn debygol o ddod yn ddatgysylltiedig.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -4190,6 +4607,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "access doors with a sliding action which will not remain closed or is likely to fly open inadvertently.",
+            "deficiencyTextWelsh": "drysau mynediad gyda gweithred llithro na fydd yn aros ar gau neu sy'n debygol o hedfan ar agor yn anfwriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4199,6 +4617,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "access doors with a hinged action which will not remain closed or is likely to fly open inadvertently.",
+            "deficiencyTextWelsh": "drysau mynediad gyda gweithred colfachog na fydd yn aros ar gau neu sy'n debygol o hedfan ar agor yn anfwriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4208,6 +4627,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which when secured in the open position obscures a position lamp, direction indicator or rear retro reflector.",
+            "deficiencyTextWelsh": "sydd, o'i sicrhau yn y safle agored, yn cuddio lamp safle, dangosydd cyfeiriad neu adlewyrchydd retro cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4219,6 +4639,7 @@
     "id": 26,
     "imNumber": 21,
     "imDescription": "Interior of Body, Passenger Entrances, Exit Steps and Platforms",
+    "imDescriptionWelsh": "Tu Mewn i'r Corff, Mynedfeydd Teithwyr, Grisiau Gadael a Llwyfannau",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -4254,6 +4675,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Body Interior:",
+        "itemDescriptionWelsh": "Tu mewn i'r Corff:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4262,6 +4684,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "access to any exit obstructed.",
+            "deficiencyTextWelsh": "mynediad i unrhyw allanfa wedi'i rwystro.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4271,6 +4694,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "steps and stairways, retractable steps, gangways, platforms or floor traps: in a deteriorated condition.",
+            "deficiencyTextWelsh": "grisiau, grisiau y gellir eu tynnu'n ôl, tramwyfeydd, llwyfannau neu drapiau llawr: mewn cyflwr gwaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4280,6 +4704,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "steps and stairways, retractable steps, gangways, platforms or floor traps: damaged or insecure but unlikely to collapse in normal use.",
+            "deficiencyTextWelsh": "grisiau, grisiau y gellir eu tynnu'n ôl, tramwyfeydd, llwyfannau neu drapiau llawr: wedi'u difrodi neu'n ansicr ond yn annhebygol o gwympo mewn defnydd arferol. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4289,6 +4714,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "steps and stairways, retractable steps, gangways, platforms or floor traps: so damaged or insecure or in such a condition that they are likely to collapse in normal use.",
+            "deficiencyTextWelsh": "grisiau, grisiau y gellir eu tynnu'n ôl, tramwyfeydd, llwyfannau neu drapiau llawr: wedi'u difrodi neu'n ansicr neu mewn cyflwr o'r fath fel eu bod yn debygol o ddymchwel mewn defnydd arferol.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           },
@@ -4298,6 +4724,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a floor trap locking device worn or ineffective so that the trap may become displaced.",
+            "deficiencyTextWelsh": "dyfais cloi trap llawr wedi treulio neu'n aneffeithiol er mwyn i'r trap gael ei ddadleoli.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -4306,6 +4733,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Retractable steps with:",
+        "itemDescriptionWelsh": "Camau y gellir eu tynnu'n ôl gyda:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4314,6 +4742,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a step which will not retract or remain retracted.",
+            "deficiencyTextWelsh": "cam na fydd yn tynnu'n ôl nac yn parhau i gael ei dynnu'n ôl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4323,6 +4752,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a step which will not operate or operates incorrectly.",
+            "deficiencyTextWelsh": "cam na fydd yn gweithredu neu'n gweithredu'n anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4332,6 +4762,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "driver able to move vehicle without being aware that the step is in the down position e.g. direct sight or mirror or warning device or interlock.",
+            "deficiencyTextWelsh": "gyrrwr yn gallu symud cerbyd heb fod yn ymwybodol bod y cam yn y safle i lawr e.e. golwg uniongyrchol neu ddrych neu ddyfais rhybuddio neu gyd-gloi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4341,6 +4772,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "driver able to move vehicle without being given an audible warning when a manually operated step is not fully retracted on Bus Directive and ECE regulation vehicles.",
+            "deficiencyTextWelsh": "gyrrwr yn gallu symud cerbyd heb gael rhybudd clywadwy pan nad yw cam a weithredir â llaw yn cael ei dynnu'n ôl yn llawn ar Cyfarwyddeb Bws a cherbydau rheoleiddio ECE.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4350,6 +4782,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "driver able to move vehicle when a power operated step is in the down position on Bus Directive and ECE regulation vehicles, without an effective safety device to prevent the power operated steps from operating with the vehicle in motion.",
+            "deficiencyTextWelsh": "gyrrwr sy'n gallu symud cerbyd pan fod cam a weithredir â phŵer yn y sefyllfa i lawr ar Cyfarwyddeb Bws a cherbydau rheoleiddio ECE, heb ddyfais ddiogelwch effeithiol i atal y camau pŵer rhag gweithredu gyda'r cerbyd yn symud.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4359,6 +4792,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a step insecure.",
+            "deficiencyTextWelsh": "cam ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4368,6 +4802,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "non-slip material defective.",
+            "deficiencyTextWelsh": "deunydd gwrthlithro yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4376,6 +4811,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A Seat:",
+        "itemDescriptionWelsh": "Sedd:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4384,6 +4820,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, damaged or weakened so that the damaged seat structure or covering could endanger passengers or damage their clothing.",
+            "deficiencyTextWelsh": "yn ansefydlog, wedi'i ddifrodi neu wedi'i wanhau fel y gallai strwythur neu orchudd y sedd sydd wedi'i ddifrodi beryglu teithwyr neu ddifrodi eu dillad.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4393,6 +4830,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "layout which has been changed without approval and which could endanger passengers.",
+            "deficiencyTextWelsh": "cynllun sydd wedi'i newid heb gymeradwyaeth ac a allai beryglu teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4402,6 +4840,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "with covering(s) in such a condition that they are likely to soil passengers clothing.",
+            "deficiencyTextWelsh": "gyda gorchudd(ion) yn y fath gyflwr fel eu bod yn debygol o faeddu dillad teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4411,6 +4850,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "number reduced from the approved number.",
+            "deficiencyTextWelsh": "nifer wedi gostwng o'r nifer cymeradwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4420,6 +4860,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "number increased from the approved number.",
+            "deficiencyTextWelsh": "nifer wedi cynyddu o'r nifer cymeradwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4428,6 +4869,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Crew Seats:",
+        "itemDescriptionWelsh": "Seddi Criw:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4436,6 +4878,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "which encroach into gangways or exits and do not automatically retract when not in use.",
+            "deficiencyTextWelsh": "sy'n tresmasu ar gangiau neu allanfeydd ac nad ydynt yn tynnu'n ôl yn awtomatig pan nad ydynt yn cael eu defnyddio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4445,6 +4888,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "without a legible notice saying “for crew use only” or similar on or adjacent to the seat or not identified as for crew use on a Bus Directive and ECE regulation vehicle.",
+            "deficiencyTextWelsh": "heb hysbysiad darllenadwy yn dweud “at ddefnydd criw yn unig” neu debyg ar y sedd neu gerllaw iddi neu heb ei nodi fel ar gyfer defnydd criw ar Cyfarwyddeb Bws a cherbyd rheoleiddio ECE.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4453,6 +4897,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Grab rails, straps, stanchions, guard rails and barriers",
+        "itemDescriptionWelsh": "Cydio rheiliau, strapiau, stanchions, rheiliau amddiffyn a rhwystrau",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4461,6 +4906,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "missing, insecure and not likely to endanger passengers.",
+            "deficiencyTextWelsh": "ar goll, yn ansefydlog ac ddim yn debygol o beryglu teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4470,6 +4916,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "so insecure and in such a condition they are likely to endanger passengers.",
+            "deficiencyTextWelsh": "mor ansefydlog ac yn y fath gyflwr y maent yn debygol o beryglu teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4478,6 +4925,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Parcel racks in such a condition",
+        "itemDescriptionWelsh": "Rheseli parseli yn y fath gyflwr",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4486,6 +4934,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "that allows articles to fall onto the driver or passengers.",
+            "deficiencyTextWelsh": "sy'n caniatáu i eitemau ddisgyn ar y gyrrwr neu'r teithwyr.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -4494,6 +4943,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "Ventilation:",
+        "itemDescriptionWelsh": "Awyru:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4502,6 +4952,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "forced ventilation equipment ineffective. (not Schedule 6 minibuses.)",
+            "deficiencyTextWelsh": "offer awyru gorfodol yn aneffeithiol. (nid bysiau mini Atodlen 6.)",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4511,6 +4962,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any ventilator, opening windows or roof hatches insecure.",
+            "deficiencyTextWelsh": "unrhyw awyriadur, agor ffenestri neu agoriadau to yn ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4520,6 +4972,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "more than 50% of the ventilator system (i.e. opening windows, ventilators and roof hatches) inoperative where forced air ventilation is not available.",
+            "deficiencyTextWelsh": "mwy na 50% o’r system awyru (h.y. agor ffenestri, awyriaduron a llinellau to) yn anweithredol lle nad oes system awyru gorfodol ar gael.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4528,6 +4981,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "Engine interior covers",
+        "itemDescriptionWelsh": "Gorchuddion mewnol injan",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4536,6 +4990,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing, contaminated to a degree which constitutes a fire risk, or which allows fumes to penetrate passenger saloon.",
+            "deficiencyTextWelsh": "ar goll, wedi'i halogi i raddau sy'n gyfystyr â risg tân, neu sy'n caniatáu i fygdarth dreiddio i salŵn teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4544,6 +4999,7 @@
       {
         "itemNumber": 9,
         "itemDescription": "Interior lighting with:",
+        "itemDescriptionWelsh": "Goleuadau mewnol gyda:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4552,6 +5008,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "inadequate illumination of saloon interior, steps, platform, staircase and other facilities (interior lights only apply to steps for Schedule 6 minibuses).",
+            "deficiencyTextWelsh": "goleuo annigonol o du mewn y salŵn, grisiau, platfform, grisiau a chyfleusterau eraill (dim ond i risiau ar gyfer bysiau mini Atodlen 6 y mae goleuadau mewnol yn berthnasol).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4561,6 +5018,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "completely inoperative lamp(s) for illumination of saloon interior, steps, platform, staircase and other facilities (interior lights only apply to steps for Schedule 6 minibuses).",
+            "deficiencyTextWelsh": "lamp(iau) cwbl anweithredol ar gyfer goleuo tu fewn y salŵn, grisiau, platfform, grisiau a chyfleusterau eraill (dim ond i risiau ar gyfer bysiau mini Atodlen 6 y mae goleuadau mewnol yn berthnasol).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4569,6 +5027,7 @@
       {
         "itemNumber": 10,
         "itemDescription": "Passenger Communication with driver:",
+        "itemDescriptionWelsh": "Cyfathrebu â'r gyrrwr gan deithiwr:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4577,6 +5036,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing or inoperative.",
+            "deficiencyTextWelsh": "ar goll neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4586,6 +5046,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not give a visual indication to passengers that the bus is stopping on Bus Directive and ECE regulation vehicles which carry standing passengers.",
+            "deficiencyTextWelsh": "nad yw'n rhoi arwydd gweledol i deithwyr bod y bws yn stopio ar gerbydau'r Gyfarwyddeb Bysiau a cherbydau rheoleiddio ECE sy'n cludo teithwyr sy'n sefyll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4594,6 +5055,7 @@
       {
         "itemNumber": 11,
         "itemDescription": "Interior surfaces:",
+        "itemDescriptionWelsh": "Arwynebau mewnol:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4602,6 +5064,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure or damaged so that it is likely to cause injury to passengers.",
+            "deficiencyTextWelsh": "yn ansefydlog neu wedi'i ddifrodi fel ei fod yn debygol o achosi anaf i deithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4611,6 +5074,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "contaminated so that they are likely to soil passengers clothing.",
+            "deficiencyTextWelsh": "wedi'u halogi fel eu bod yn debygol o faeddu dillad teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4619,6 +5083,7 @@
       {
         "itemNumber": 12,
         "itemDescription": "First Aid Kit:",
+        "itemDescriptionWelsh": "Pecyn Cymorth Cyntaf:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4627,6 +5092,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing, inaccessible or in poor or contaminated condition.",
+            "deficiencyTextWelsh": "ar goll, yn anhygyrch neu mewn cyflwr gwael neu halogedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4636,6 +5102,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "receptacle not marked.",
+            "deficiencyTextWelsh": "cynhwysydd heb ei farcio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4644,6 +5111,7 @@
       {
         "itemNumber": 13,
         "itemDescription": "Fire extinguisher",
+        "itemDescriptionWelsh": "Diffoddwr tân",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4652,6 +5120,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing, inaccessible, discharged, incorrect type or in an obviously poor condition.",
+            "deficiencyTextWelsh": "ar goll, yn anhygyrch, wedi'i ryddhau, math anghywir neu mewn cyflwr amlwg wael.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4660,6 +5129,7 @@
       {
         "itemNumber": 14,
         "itemDescription": "Any “other facility” (including those listed in 15-19 below) which is",
+        "itemDescriptionWelsh": "Unrhyw “gyfleuster arall” (gan gynnwys y rhai a restrir yn 15-19 isod) sydd",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4668,6 +5138,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete, insecure and/or incorrect function and is likely to endanger passengers.",
+            "deficiencyTextWelsh": "swyddogaeth anghyflawn, ansefydlog a/neu anghywir ac yn debygol o beryglu teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4676,6 +5147,7 @@
       {
         "itemNumber": 15,
         "itemDescription": "Wheelchair lifts/ramps:",
+        "itemDescriptionWelsh": "Lifftiau/rampiau cadair olwyn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4684,6 +5156,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the strength of the lift or ramp is significantly impaired.",
+            "deficiencyTextWelsh": "mae cryfder y lifft neu'r ramp yn cael ei amharu'n sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4693,6 +5166,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "there are sharp edges or other protrusions on a lift or ramp which are likely to cause injury.",
+            "deficiencyTextWelsh": "os oes ymylon miniog neu allwthiadau eraill ar lifft neu ramp sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4702,6 +5176,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "defective in operation and not likely to injure passengers, pedestrians or other road users.",
+            "deficiencyTextWelsh": "diffygiol yn ei weithrediad a ddim yn debygol o anafu teithwyr, cerddwyr neu ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4711,6 +5186,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "defective in operation to the extent that it is likely to injure passengers, pedestrians or other road users.",
+            "deficiencyTextWelsh": "diffygiol yn ei weithrediad a ddim yn debygol o anafu teithwyr, cerddwyr neu ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4720,6 +5196,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "non-slip surface on ramp defective.",
+            "deficiencyTextWelsh": "arwyneb gwrthlithro ar y ramp yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4729,6 +5206,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "non-slip surface on ramp defective to such an extent that it is likely to cause injuries.",
+            "deficiencyTextWelsh": "arwyneb gwrthlithro ar ramp yn ddiffygiol i'r fath raddau fel ei fod yn debygol o achosi anafiadau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4738,6 +5216,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a lift or ramp which cannot be secured in stored position.",
+            "deficiencyTextWelsh": "lifft neu ramp na ellir ei glymu yn ei le storio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4746,6 +5225,7 @@
       {
         "itemNumber": 16,
         "itemDescription": "Wheelchair spaces:",
+        "itemDescriptionWelsh": "Lleoedd cadeiriau olwyn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4754,6 +5234,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any wheelchair floor fitting loose or likely to cause passengers to trip.",
+            "deficiencyTextWelsh": "unrhyw osodiadau llawr cadair olwyn yn rhydd neu'n debygol o achosi teithwyr i faglu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4763,6 +5244,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any padded backrest missing (when known to be an original fitting), insecure or in a condition which is likely to cause injury to passengers.",
+            "deficiencyTextWelsh": "unrhyw gynhalydd cefn padio ar goll (pan wybod ei fod yn ffitiad gwreiddiol), yn ansefydlog neu mewn cyflwr sy'n debygol o achosi anaf i deithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4772,6 +5254,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any stanchion, retractable rail/movable device, partition or panel relating to the wheelchair area missing, insecure or in a condition which is likely to cause injury to passengers.",
+            "deficiencyTextWelsh": "unrhyw stansiwn, rheilen ôl-dynadwy/dyfais symudol, pared neu banel sy'n ymwneud â'r ardal gadair olwyn sydd ar goll, yn anniogel neu mewn cyflwr sy'n debygol o achosi anaf i deithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4780,6 +5263,7 @@
       {
         "itemNumber": 17,
         "itemDescription": "Combustion heater",
+        "itemDescriptionWelsh": "Gwresogydd hylosgi",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4788,6 +5272,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with fuel filler inside vehicle",
+            "deficiencyTextWelsh": "gyda llenwr tanwydd y tu mewn i'r cerbyd",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4796,6 +5281,7 @@
       {
         "itemNumber": 18,
         "itemDescription": "Cookers/refrigerators/drinks dispenser",
+        "itemDescriptionWelsh": "Ffyrnau/oergelloedd/dosbarthwr diodydd",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4804,6 +5290,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "in such a condition that they are likely to endanger passengers.",
+            "deficiencyTextWelsh": "yn y fath gyflwr fel eu bod yn debygol o beryglu teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4812,6 +5299,7 @@
       {
         "itemNumber": 19,
         "itemDescription": "Television/video for passenger entertainment with the screen placed",
+        "itemDescriptionWelsh": "Teledu/fideo ar gyfer adloniant i deithwyr gyda'r sgrin wedi'i osod",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4820,6 +5308,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "where driver can view whilst driving.",
+            "deficiencyTextWelsh": "lle gall gyrrwr weld wrth yrru.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4831,6 +5320,7 @@
     "id": 27,
     "imNumber": 22,
     "imDescription": "Mirrors and Indirect Vision Devices",
+    "imDescriptionWelsh": "Drychau a Dyfeisiau Golwg Anuniongyrchol",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -4863,6 +5353,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Part of any required close proximity, front mirror or camera for an indirect visual device",
+        "itemDescriptionWelsh": "Rhan o unrhyw agosrwydd, drych blaen neu gamera gofynnol ar gyfer dyfais weledol anuniongyrchol",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -4871,6 +5362,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is fitted less than 2 metres from the ground.",
+            "deficiencyTextWelsh": "wedi'i osod llai na 2 fetr o'r ddaear.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -4879,6 +5371,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A required mirror or indirect vision device",
+        "itemDescriptionWelsh": "Drych gofynnol neu ddyfais golwg anuniongyrchol",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -4887,6 +5380,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with minor damage that does not obviously interfere with the view to the rear or nearside or front where required of anyone sitting in the driving seats.",
+            "deficiencyTextWelsh": "gyda mân ddifrod nad yw'n amlwg yn ymyrryd â'r olygfa i'r cefn neu'r ochr agosaf neu'r blaen lle bod angen gan unrhyw un sy'n eistedd yn y seddi gyrru.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -4896,6 +5390,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "in such a condition that anyone sitting in the driving seat cannot see clearly towards the rear or nearside or front where required.",
+            "deficiencyTextWelsh": "mewn cyflwr o'r fath fel na all unrhyw un sy'n eistedd yn y sedd yrru weld yn glir tuag at y cefn neu'r ochr agosaf neu'r tu blaen lle bod angen.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -4904,6 +5399,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "A mirror/indirect vision device or its mounting bracket",
+        "itemDescriptionWelsh": "Drych/dyfais golwg anuniongyrchol neu ei fraced mowntio",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -4912,6 +5408,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure or structurally deteriorated.",
+            "deficiencyTextWelsh": "ansefydlog neu wedi dirywio yn strwythurol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -4920,6 +5417,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Not fitted with the correct number or type(s)",
+        "itemDescriptionWelsh": "Heb ei ffitio â'r rhif neu fath(au) cywir",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -4928,6 +5426,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "of mirror, or other indirect vision device.",
+            "deficiencyTextWelsh": "o ddrych, neu ddyfais golwg anuniongyrchol arall.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -4936,6 +5435,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A required mirror or indirect vision device",
+        "itemDescriptionWelsh": "Drych gofynnol neu ddyfais golwg anuniongyrchol",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4944,6 +5444,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with minor damage that does not obviously interfere with the view to the rear or nearside of anyone sitting in the driving seats.",
+            "deficiencyTextWelsh": "gyda mân ddifrod nad yw'n amlwg yn amharu ar olygfa y tu ôl neu'r ochr agosaf i unrhyw un sy'n eistedd yn y seddi gyrru.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -4953,6 +5454,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "in such a condition that anyone sitting in the driving seat cannot see clearly towards the rear or nearside.",
+            "deficiencyTextWelsh": "mewn cyflwr o'r fath fel na all unrhyw un sy'n eistedd yn y sedd yrru weld yn glir tuag at y cefn neu'r ochr agosaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4961,6 +5463,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A mirror/indirect vision device or its mounting bracket",
+        "itemDescriptionWelsh": "Drych/dyfais golwg anuniongyrchol neu ei fraced mowntio",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4969,6 +5472,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure or structurally deteriorated.",
+            "deficiencyTextWelsh": "ansefydlog neu wedi dirywio yn strwythurol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4977,6 +5481,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "A mirror/indirect vision device or periscope",
+        "itemDescriptionWelsh": "Drych/dyfais golwg anuniongyrchol neu perisgop",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -4985,6 +5490,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure and in such a condition that it is likely to injure the driver or passengers.",
+            "deficiencyTextWelsh": "yn ansefydlog ac yn y fath gyflwr fel ei fod yn debygol o anafu’r gyrrwr neu’r teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -4996,6 +5502,7 @@
     "id": 28,
     "imNumber": 23,
     "imDescription": "Glass and View of the Road",
+    "imDescriptionWelsh": "Gwydr a Golygfa o'r Ffordd",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -5028,6 +5535,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A Windscreen:",
+        "itemDescriptionWelsh": "Sgrin wynt:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5036,6 +5544,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with an obstruction, damage or discolouration which materially affects view to the front or the sides through the area of windscreen not swept by the wipers (zone C).",
+            "deficiencyTextWelsh": "gyda rhwystr, difrod neu afliwiad sy'n effeithio'n sylweddol ar olwg y blaen neu'r ochrau trwy ardal y ffenestr flaen nad yw'n cael ei hysgubo gan y sychwyr (parth C).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5045,6 +5554,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "with an obstruction, damage or discolouration which materially affects view to the front or the sides through the area of windscreen swept by the wipers.",
+            "deficiencyTextWelsh": "gyda rhwystr, difrod neu afliwiad sy'n effeithio'n sylweddol ar olwg y blaen neu'r ochrau trwy ardal y ffenestr flaen sy'n cael ei hysgubo gan y sychwyr. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5054,6 +5564,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with a crack in the windscreen outside of the area swept by the wipers (zone C).",
+            "deficiencyTextWelsh": "gyda hollt yn y ffenestr flaen y tu allan i'r ardal wedi'i hysgubo gan y sychwyr (parth C).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5063,6 +5574,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "with a crack passing through the swept area which renders the screen insecure or which materially affects view to the front or the sides through the area of windscreen swept by the wipers.",
+            "deficiencyTextWelsh": "gyda hollt yn mynd trwy'r ardal sychu sy'n gwneud y sgrin yn anniogel neu sy'n effeithio'n sylweddol ar olwg y blaen neu'r ochrau trwy ardal y ffenestr flaen sy'n cael ei hysgubo gan y sychwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5072,6 +5584,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with any crack where there is noticeable displacement of the surfaces on either side which has an adverse effect on the condition and operation of the windscreen wipers.",
+            "deficiencyTextWelsh": "gydag unrhyw hollt lle mae'r arwynebau'n cael eu dadleoli'n amlwg ar y naill ochr a'r llall sy'n cael effaith andwyol ar gyflwr a gweithrediad y sychwyr sgrin wynt.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5081,6 +5594,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with damage which exposes the inner layer of a laminated screen.",
+            "deficiencyTextWelsh": "gyda difrod sy'n datgelu haen fewnol sgrin wedi'i lamineiddio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5089,6 +5603,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "A windscreen or window:",
+        "itemDescriptionWelsh": "Ffenestr wynt neu ffenestr:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5097,6 +5612,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure that it is likely to fall out or damaged to the extent that it presents a danger to occupants or to other road users.",
+            "deficiencyTextWelsh": "mor ansefydlog fel ei fod yn debygol o gwympo allan neu ei ddifrodi i'r graddau ei fod yn achosi perygl i feddianwyr neu ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5106,6 +5622,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with damage or obstruction, which impairs the driver’s view of a mandatory mirror.",
+            "deficiencyTextWelsh": "gyda difrod neu rwystr, sy'n amharu ar olwg y gyrrwr o ddrych gorfodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5115,6 +5632,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not made from safety glass or safety glazing as specified.",
+            "deficiencyTextWelsh": "heb ei wneud o wydr diogelwch neu wydr diogelwch fel y nodir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5124,6 +5642,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "made of safety glass which does not show an acceptable marking.",
+            "deficiencyTextWelsh": "wedi'i wneud o wydr diogelwch nad yw'n dangos marc derbyniol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5133,6 +5652,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "in such a condition it would allow water to leak into the passenger areas.",
+            "deficiencyTextWelsh": "mewn cyflwr o'r fath byddai'n caniatáu i ddŵr ollwng i'r ardaloedd teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5142,6 +5662,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "windscreen or outside window missing.",
+            "deficiencyTextWelsh": "ffenestr flaen neu ffenestr allanol ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5151,6 +5672,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "or internal screen or partition so insecure that it is likely to fall out in normal use or cause injury to any person on the vehicle.",
+            "deficiencyTextWelsh": "neu sgrin fewnol neu raniad mor ansicr fel ei fod yn debygol o ddisgyn allan yn y defnydd arferol neu achosi anaf i unrhyw berson ar y cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -5159,6 +5681,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A guard rail or barrier at a window, internal screen or partition:",
+        "itemDescriptionWelsh": "Rheilen warchod neu rwystr wrth ffenestr, sgrin fewnol neu raniad:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5167,6 +5690,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing, insecure or damaged to the extent that injury to a passenger is likely.",
+            "deficiencyTextWelsh": "ar goll, yn ansicr neu wedi'i ddifrodi i'r graddau y mae anaf i deithiwr yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5178,6 +5702,7 @@
     "id": 29,
     "imNumber": 24,
     "imDescription": "Accessibility Features",
+    "imDescriptionWelsh": "Nodweddion Hygyrchedd",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -5210,6 +5735,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Wheelchair spaces:",
+        "itemDescriptionWelsh": "Lleoedd cadeiriau olwyn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5218,6 +5744,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "any wheelchair restraint components deteriorated, insecure or defective but not likely to affect it's function.",
+            "deficiencyTextWelsh": "unrhyw gydrannau ataliad cadair olwyn wedi dirywio, yn ansicr neu'n ddiffygiol ond ddim yn debygol o effeithio ar ei swyddogaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5227,6 +5754,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "any wheelchair restraint components missing, or badly deteriorated, insecure and or defective to such an extent the function is obviously affected.",
+            "deficiencyTextWelsh": "unrhyw gydrannau ataliad cadair olwyn sydd ar goll, neu wedi dirywio'n wael, yn ansicr a/neu'n ddiffygiol i'r fath raddau bod y swyddogaeth yn amlwg yn cael ei heffeithio",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5236,6 +5764,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "any wheelchair user restraint components deteriorated, insecure or defective but not likely to affect it's function.",
+            "deficiencyTextWelsh": "unrhyw gydrannau ataliad defnyddiwr cadair olwyn wedi dirywio, yn ansicr neu'n ddiffygiol ond ddim yn debygol o effeithio ar ei swyddogaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5245,6 +5774,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "any wheelchair user restraint components missing,  or badly deteriorated, insecure and or defective to such an extent the function is obviously affected.",
+            "deficiencyTextWelsh": "unrhyw gydrannau ataliad defnyddiwr cadair olwyn sydd ar goll, neu wedi dirywio'n wael, yn ansicr a/neu'n ddiffygiol i'r fath raddau bod y swyddogaeth yn amlwg yn cael ei heffeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5253,6 +5783,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "For each wheelchair space designed for a rearward facing wheelchair:",
+        "itemDescriptionWelsh": "Ar gyfer pob gofod cadair olwyn a ddyluniwyd ar gyfer cadair olwyn sy'n wynebu'r cefn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5261,6 +5792,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any padded backrest missing, insecure or in a condition which is likely to cause injury to passengers.",
+            "deficiencyTextWelsh": "unrhyw gynhalydd cefn padio ar goll, yn ansefydlog neu mewn cyflwr sy'n debygol o achosi anaf i deithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5270,6 +5802,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any stanchion, fixed rail, retractable/movable device, partition or panel relating to the wheelchair area missing, insecure or in a condition which is likely to cause injury to passengers.",
+            "deficiencyTextWelsh": "unrhyw stansiwn, rheilen sefydlog, dyfais dynadwy/symudol, pared neu banel sy'n ymwneud â'r ardal gadair olwyn sydd ar goll, yn anniogel neu mewn cyflwr sy'n debygol o achosi anaf i deithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5278,6 +5811,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Boarding lifts and boarding ramps:",
+        "itemDescriptionWelsh": "Lifftiau byrddio a rampiau byrddio:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5286,6 +5820,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a lift or ramp missing, insecure or the strength of the lift or ramp is significantly impaired.",
+            "deficiencyTextWelsh": "lifft neu ramp ar goll, yn ansicr neu mae cryfder y lifft neu'r ramp yn cael ei amharu'n sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5295,6 +5830,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a lift or ramp which does not function as intended or does not operate through the required range of movement.",
+            "deficiencyTextWelsh": "lifft neu ramp nad yw'n gweithio fel y bwriadwyd neu nad yw'n gweithredu drwy'r ystod symudiadau gofynnol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5304,6 +5840,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "there are sharp edges or other protrusions on a lift or ramp which are likely to cause injury.",
+            "deficiencyTextWelsh": "os oes ymylon miniog neu allwthiadau eraill ar lifft neu ramp sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5313,6 +5850,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "the band of contrasting colour on a lift or ramp surface edge is missing or has deteriorated to the extent that it is visually ineffective.",
+            "deficiencyTextWelsh": "mae'r band o liw cyferbyniol ar ymyl lifft neu wyneb ramp ar goll neu wedi dirywio i'r graddau ei fod yn weledol aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5322,6 +5860,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a lift surface does not have an effective device for preventing wheelchairs from rolling off or the device is ineffective.",
+            "deficiencyTextWelsh": "nid oes gan arwyneb lifft ddyfais effeithiol ar gyfer atal cadeiriau olwyn rhag rholio i ffwrdd neu mae'r ddyfais yn aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5331,6 +5870,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "cannot be stowed, failure or malfunction of any stowage retaining device (including failure to release without power supplied where appropriate) but safety not affected.",
+            "deficiencyTextWelsh": "ni ellir ei storio, methiant neu gamweithio unrhyw ddyfais cadw storle (gan gynnwys methiant i ryddhau heb gyflenwad pŵer lle ei fod yn briodol) ond ni effeithir ar ddiogelwch.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5340,6 +5880,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be safely stowed, failure or malfunction of any stowage retaining device (including failure to release without power supplied where appropriate) that affects safety.",
+            "deficiencyTextWelsh": "ni ellir ei storio'n ddiogel, methiant neu gamweithio unrhyw ddyfais cadw storle (gan gynnwys methiant i ryddhau heb gyflenwad pŵer lle ei fod yn briodol) sy'n effeithio ar ddiogelwch.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5349,6 +5890,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the safety device intended to prevent the vehicle being driven normally when the lift or ramp is not in its intended position for vehicle travel, is ineffective.",
+            "deficiencyTextWelsh": "mae'r ddyfais ddiogelwch a fwriedir i atal y cerbyd rhag cael ei yrru fel arfer pan nad yw'r lifft neu'r ramp yn y sefyllfa a fwriadwyd ar gyfer teithio mewn cerbyd, yn aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5357,6 +5899,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "A power operated lift or ramp (additional requirements):",
+        "itemDescriptionWelsh": "Lifft neu ramp a weithredir gan bŵer (gofynion ychwanegol):",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5365,6 +5908,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "defective in operation to the extent that it is likely to injure passengers, pedestrians or other road users.",
+            "deficiencyTextWelsh": "diffygiol yn ei weithrediad i'r graddau ei fod yn debygol o anafu teithwyr, cerddwyr neu ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5374,6 +5918,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with an audible device missing or inoperative. (except an Annex VII done vehicle with a powered lift).",
+            "deficiencyTextWelsh": "gyda dyfais glywadwy ar goll neu'n anweithredol. (ac eithrio cerbyd wedi'i orffen yn Atodiad VII gyda lifft pŵer).",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5383,6 +5928,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "on an Annex VII vehicle with a powered ramp the yellow warning lights are defective.",
+            "deficiencyTextWelsh": "ar gerbyd Atodiad VII gyda ramp wedi'i bweru mae'r goleuadau rhybudd melyn yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5392,6 +5938,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "on an Annex VII vehicle with a powered ramp the yellow warning lights are missing.",
+            "deficiencyTextWelsh": "ar gerbyd Atodiad VII gyda ramp wedi'i bweru mae'r goleuadau rhybudd melyn ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5401,6 +5948,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "incapable of being operated manually and the vehicle does not have a portable ramp.",
+            "deficiencyTextWelsh": "yn analluog i gael ei weithredu â llaw ac nid oes gan y cerbyd ramp cludadwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5410,6 +5958,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "without an effective safety device to prevent the lift or ramp from operating with the vehicle in motion.",
+            "deficiencyTextWelsh": "heb ddyfais ddiogelwch effeithiol i atal y lifft neu ramp rhag weithredu gyda'r cerbyd yn symud.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5419,6 +5968,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "safety device to stop the extension or retraction of a ramp or lift on meeting an obstruction inoperative and is likely to cause injury.",
+            "deficiencyTextWelsh": "dyfais ddiogelwch i atal estyniad neu dynnu'n ôl y ramp neu'r lifft wrth gwrdd â rhwystr sy'n anweithredol ac sy'n debygol o achosi anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5427,6 +5977,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Portable Ramp (additional requirements)",
+        "itemDescriptionWelsh": "Ramp cludadwy (gofynion ychwanegol)",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5435,6 +5986,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with no suitable storage stowage position and likely to cause injury to any passenger or crew.",
+            "deficiencyTextWelsh": "heb safle storio addas ac yn debygol o achosi anaf i unrhyw deithiwr neu griw.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5443,6 +5995,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Entrance and exit optical device to allow driver to view wheelchair entrances and exits:",
+        "itemDescriptionWelsh": "Dyfais optegol mynediad ac allanfa i alluogi gyrrwr i weld mynedfeydd ac allanfeydd cadeiriau olwyn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5451,6 +6004,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing or inefective.",
+            "deficiencyTextWelsh": "ar goll neu'n aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5460,6 +6014,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure but unlikely to become detached.",
+            "deficiencyTextWelsh": "yn ansefydlog ond yn annhebygol o ddatgysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5469,6 +6024,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to such an extent that detachment is imminent.",
+            "deficiencyTextWelsh": "ansefydlog i'r fath raddau fel bod datodiad ar fin digwydd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -5477,6 +6033,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "A required sign/marking or safety instruction",
+        "itemDescriptionWelsh": "Arwydd/marc neu gyfarwyddyd diogelwch gofynnol",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5485,6 +6042,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "missing or illegible.",
+            "deficiencyTextWelsh": "ar goll neu'n annarllenadwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5493,6 +6051,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "Communication devices:",
+        "itemDescriptionWelsh": "Dyfeisiau cyfathrebu:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5501,6 +6060,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any internal wheelchair space communication device missing or inoperative.",
+            "deficiencyTextWelsh": "unrhyw ddyfais cyfathrebu ardal cadair olwyn fewnol ar goll neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5510,6 +6070,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any external communication device missing or inoperative.",
+            "deficiencyTextWelsh": "unrhyw ddyfais cyfathrebu allanol ar goll neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5518,6 +6079,7 @@
       {
         "itemNumber": 9,
         "itemDescription": "Communication devices: Lighting specifically intended for wheelchair users to board or alight in safety",
+        "itemDescriptionWelsh": "Dyfeisiau cyfathrebu: Goleuadau a fwriadwyd yn benodol ar gyfer defnyddwyr cadeiriau olwyn i fynd ar neu bant yn ddiogel",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5526,6 +6088,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing, inoperative or deteriorated to the extent that the illumination is significantly reduced.",
+            "deficiencyTextWelsh": "ar goll, yn anweithredol neu wedi dirywio i'r graddau bod y goleuo'n cael ei leihau'n sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5534,6 +6097,7 @@
       {
         "itemNumber": 10,
         "itemDescription": "Floors and gangways slip resistant material",
+        "itemDescriptionWelsh": "Lloriau a llwybrau sy'n gwrthsefyll llithro",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5542,6 +6106,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "deteriorated to the extent that it is no longer effective.",
+            "deficiencyTextWelsh": "dirywio i'r graddau nad yw bellach yn effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5550,6 +6115,7 @@
       {
         "itemNumber": 11,
         "itemDescription": "Steps with:",
+        "itemDescriptionWelsh": "Camau gyda:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5558,6 +6124,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "slip resistant material deteriorated to the extent that it is no longer effective.",
+            "deficiencyTextWelsh": "deunydd sy'n gwrthsefyll llithro wedi dirywio i'r graddau nad yw bellach yn effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5567,6 +6134,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "band of contrasting colour is missing or deteriorated to the extent that it is no longer visually effective.",
+            "deficiencyTextWelsh": "band o liw cyferbyniol ar goll neu wedi dirywio i'r graddau nad yw bellach yn weledol effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5576,6 +6144,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any interlock and/or safety device applicable to folding, extendable and/or power steps is inoperative.",
+            "deficiencyTextWelsh": "unrhyw ddyfais cyd-gloi a/neu ddiogelwch sy'n berthnasol i gamau plygu, estynadwy a/neu bŵer yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5584,6 +6153,7 @@
       {
         "itemNumber": 12,
         "itemDescription": "Kneeling suspension which:",
+        "itemDescriptionWelsh": "Hongiad penlinio sydd:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -5592,6 +6162,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "has an operating control, which is inadequately marked.",
+            "deficiencyTextWelsh": "â rheolydd gweithredu, nad yw wedi'i farcio'n ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5601,6 +6172,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has controls which are incapable of stopping and reversing the lowering process.",
+            "deficiencyTextWelsh": "â rheolyddion na allant atal a gwrthdroi'r broses ostwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -5610,6 +6182,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not have an effective interlock to prevent the vehicle from being driven at speeds in excess of 5km/h with the vehicle lower than normal height.",
+            "deficiencyTextWelsh": "heb gyd-gloi effeithiol i atal y cerbyd rhag cael ei yrru ar gyflymder o fwy na 5km/h gyda'r cerbyd yn is na'r uchder arferol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -5621,6 +6194,7 @@
     "id": 30,
     "imNumber": 25,
     "imDescription": "Windscreen Wipers and Washers",
+    "imDescriptionWelsh": "Sychwyr a Golchwyr Sgrin Wynt",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -5653,6 +6227,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Switch(es) controlling windscreen wipers and/or washers",
+        "itemDescriptionWelsh": "Switsys sy'n rheoli sychwyr sgrin wynt a/neu wasieri",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5661,6 +6236,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "missing or defective.",
+            "deficiencyTextWelsh": "ar goll neu'n ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5669,6 +6245,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Wipers:",
+        "itemDescriptionWelsh": "Sychwyr:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5677,6 +6254,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "do not move over an adequate area.",
+            "deficiencyTextWelsh": "ddim yn symud dros ardal ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5686,6 +6264,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "do not work continually when switched on.",
+            "deficiencyTextWelsh": "ddim yn gweithio'n barhaus pan gaiff ei droi ymlaen.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5695,6 +6274,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a blade missing, insecure or so deteriorated that it cannot clear the screen effectively.",
+            "deficiencyTextWelsh": "llafn ar goll, yn ansefydlog neu wedi dirywio cymaint fel na all glirio'r sgrin yn effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5703,6 +6283,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Windscreen washers",
+        "itemDescriptionWelsh": "Golchwyr sgrin wynt",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5711,6 +6292,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not working or not providing sufficient fluid to clear the windscreen.",
+            "deficiencyTextWelsh": "ddim yn gweithio neu ddim yn darparu digon o hylif i glirio'r ffenestr flaen. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5722,6 +6304,7 @@
     "id": 31,
     "imNumber": 26,
     "imDescription": "Speedometer/Tachograph",
+    "imDescriptionWelsh": "Cyflymder/tacograff",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -5754,6 +6337,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A speedometer or tachograph (where required):",
+        "itemDescriptionWelsh": "Cyflymder neu dacograff (lle bod angen):",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5762,6 +6346,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted.",
+            "deficiencyTextWelsh": "heb ei ffitio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5771,6 +6356,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "incomplete or dial glass broken without affecting the operation.",
+            "deficiencyTextWelsh": "gwydr anghyflawn neu ddeialu wedi'i dorri heb effeithio ar y weithred.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5780,6 +6366,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete, clearly inoperative, or with dial glass missing or broken and affecting the operation.",
+            "deficiencyTextWelsh": "anghyflawn, yn amlwg yn anweithredol, neu gyda gwydr deialu ar goll neu wedi torri ac yn effeithio ar y llawdriniaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5789,6 +6376,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be illuminated.",
+            "deficiencyTextWelsh": "ni ellir ei oleuo.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5797,6 +6385,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "For all vehicles fitted with a tachograph:",
+        "itemDescriptionWelsh": "Ar gyfer pob cerbyd sydd â thacograff:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5805,6 +6394,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tachograph installation/calibration plaque missing  or damaged (where required).",
+            "deficiencyTextWelsh": "gosodiad tacograff/plac graddnodi ar goll neu wedi'i ddifrodi (lle bod angen).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5814,6 +6404,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "DIL switch cover missing, broken or damaged through interference.",
+            "deficiencyTextWelsh": "Gorchudd switsh DIL ar goll, wedi torri neu wedi'i ddifrodi oherwydd ymyrraeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5822,6 +6413,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "For vehicles required to be fitted with a tachograph:",
+        "itemDescriptionWelsh": "Ar gyfer cerbydau y mae angen gosod tacograff arnynt:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5830,6 +6422,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tachograph scale not marked in kilometres per hour (There is no requirement for tachographs to be marked in m.p.h.).",
+            "deficiencyTextWelsh": "graddfa tacograff heb ei farcio mewn cilometrau yr awr (Nid oes gofyniad i dacograffau gael eu marcio mewn m.p.h.).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5839,6 +6432,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tachograph manufacturer’s serial number/data plaque missing or not showing an “e” marking.",
+            "deficiencyTextWelsh": "rhif cyfresol gwneuthurwr tacograff/plac data ar goll neu ddim yn dangos marc “e”.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5848,6 +6442,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tachograph installation/calibration plaque out of date.",
+            "deficiencyTextWelsh": "gosodiad tacograff/plac graddnodi wedi dyddio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5857,6 +6452,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "where a digital tachograph is fitted the size of drive axle  road tyres do not comply with calibration plaque.",
+            "deficiencyTextWelsh": "pan fod tacograff digidol wedi'i osod, nid yw teiars ffordd echel gyrru maint yn cydymffurfio â phlac graddnodi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5866,6 +6462,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "“K” factor plaque missing.",
+            "deficiencyTextWelsh": "Plac ffactor “K” ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5875,6 +6472,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "seal missing, broken or where a clearly “non mandatory” seal has been fitted in place of an “official” seal.",
+            "deficiencyTextWelsh": "sêl ar goll, wedi torri neu lle mae sêl “anorfodol” amlwg wedi'i gosod yn lle sêl “swyddogol”.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5884,6 +6482,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "unable to obtain a printout from a digital tachograph.",
+            "deficiencyTextWelsh": "methu cael allbrint o dacograff digidol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5893,6 +6492,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a digital tachograph that displays a ‘K’ factor reading different to that shown on the calibration plaque (there is no allowance/tolerance as with analogue type tachographs).",
+            "deficiencyTextWelsh": "tacograff digidol sy’n dangos darlleniad ffactor ‘K’ sy’n wahanol i’r hyn a ddangosir ar y plac graddnodi (nid oes lwfans/goddefgarwch fel gyda thacograffau math analog).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5901,6 +6501,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "For vehicles not required to be fitted with a tachograph, where a tachograph is fitted in place of a speedometer:",
+        "itemDescriptionWelsh": "Ar gyfer cerbydau nad oes angen tacograff arnynt, lle gosodir tacograff yn lle cyflymdra:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5909,6 +6510,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "If a speed limiter is required (which is sensed from the tachograph head): seal missing, broken or where a clearly “non-mandatory\" seal has been fitted in place of an “official\" seal.",
+            "deficiencyTextWelsh": "Os oes angen cyfyngydd cyflymder (sy'n cael ei synhwyro o'r pen tacograff): sêl ar goll, wedi torri neu lle mae sêl amlwg “anorfodol” wedi'i gosod yn lle sêl “swyddogol”.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5918,6 +6520,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "If a speed limiter is not required: a seal (within the tachograph head) missing, broken, or where a clearly “non mandatory” seal has been fitted in place of an “official” seal. There is no requirement for the gearbox sender unit to be sealed.",
+            "deficiencyTextWelsh": "Os nad oes angen cyfyngydd cyflymder: sêl (o fewn pen y tacograff) ar goll, wedi torri, neu lle mae sêl “anorfodol” amlwg wedi'i gosod yn lle sêl “swyddogol”. Nid oes unrhyw ofyniad i'r uned anfon blwch gêr gael ei selio. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5929,6 +6532,7 @@
     "id": 32,
     "imNumber": 27,
     "imDescription": "Horn",
+    "imDescriptionWelsh": "Corn",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -5961,6 +6565,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Horn control:",
+        "itemDescriptionWelsh": "Rheolaeth corn:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -5969,6 +6574,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5978,6 +6584,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be reached easily from the driving seat.",
+            "deficiencyTextWelsh": "ni ellir ei gyrraedd yn hawdd o'r sedd yrru.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -5987,6 +6594,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -5995,6 +6603,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Horn:",
+        "itemDescriptionWelsh": "Corn:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6003,6 +6612,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not work.",
+            "deficiencyTextWelsh": "ddim yn gweithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6012,6 +6622,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is not loud enough to be heard by other road users.",
+            "deficiencyTextWelsh": "nad yw'n ddigon uchel i ddefnyddwyr eraill y ffordd ei glywed.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6021,6 +6632,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "sound not continuous or uniform.",
+            "deficiencyTextWelsh": "sain ddim yn barhaus nac yn unffurf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6030,6 +6642,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6041,6 +6654,7 @@
     "id": 33,
     "imNumber": 28,
     "imDescription": "Driving Controls",
+    "imDescriptionWelsh": "Rheolaethau Gyrru",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -6073,6 +6687,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A driving control:",
+        "itemDescriptionWelsh": "Rheolaeth yrru:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6081,6 +6696,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6090,6 +6706,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure and safe operation of the vehicle obviously affected.",
+            "deficiencyTextWelsh": "gweithrediad ansefydlog a diogel y cerbyd yn amlwg yr effeithir arnynt.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6099,6 +6716,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete.",
+            "deficiencyTextWelsh": "anghyflawn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6108,6 +6726,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "incomplete and safe operation of the vehicle obviously affected.",
+            "deficiencyTextWelsh": "gweithrediad anghyflawn a diogel y cerbyd yn amlwg yr effeithir arnynt.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6117,6 +6736,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "fractured, cracked or excessively corroded.",
+            "deficiencyTextWelsh": "wedi torri, cracio neu wedi rhydu'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6126,6 +6746,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fractured, cracked or excessively corroded and safe operation of the vehicle obviously affected.",
+            "deficiencyTextWelsh": "wedi torri, cracio neu wedi rhydu'n ormodol a gweithrediad diogel y cerbyd yn amlwg wedi'i effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6135,6 +6756,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "obstructed or impeded in its travel.",
+            "deficiencyTextWelsh": "wedi ei rwystro neu ei rwystro yn ei deithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6144,6 +6766,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "obstructed or impeded in its travel and safe operation of the vehicle obviously affected.",
+            "deficiencyTextWelsh": "wedi'i rwystro neu ei rwystro o ran teithio a gweithrediad diogel y cerbyd yr effeithir arno yn amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6153,6 +6776,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "obviously not functioning correctly.",
+            "deficiencyTextWelsh": "yn amlwg ddim yn gweithredu'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6162,6 +6786,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "obviously not functioning correctly and safe operation of the vehicle obviously affected.",
+            "deficiencyTextWelsh": "yn amlwg ddim yn gweithredu'n gywir a gweithrediad diogel y cerbyd yn amlwg yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6171,6 +6796,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with the presence of rubbish or other items likely to interfere with the proper control of the vehicle.",
+            "deficiencyTextWelsh": "gyda phresenoldeb sbwriel neu eitemau eraill sy'n debygol o amharu ar reolaeth briodol y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6180,6 +6806,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "clutch pedal anti-slip provision missing, loose, incomplete or ineffective.",
+            "deficiencyTextWelsh": "darpariaeth gwrthlithro pedal cydiwr ar goll, yn rhydd, yn anghyflawn neu'n aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6189,6 +6816,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "clutch pedal anti-slip provision missing, loose, incomplete or ineffective and safe operation of the vehicle obviously affected.",
+            "deficiencyTextWelsh": "darpariaeth gwrthlithro pedal cydiwr ar goll, yn rhydd, yn anghyflawn neu'n aneffeithiol ac yn ddiogel gweithrediad y cerbyd yn amlwg yr effeithir arno.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6197,6 +6825,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Engine stop control",
+        "itemDescriptionWelsh": "Rheoli stopio injan",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6205,6 +6834,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing or inoperative.",
+            "deficiencyTextWelsh": "ar goll neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6216,6 +6846,7 @@
     "id": 34,
     "imNumber": 30,
     "imDescription": "Steering Control",
+    "imDescriptionWelsh": "Rheoli Llywio",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -6248,6 +6879,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Steering column:",
+        "itemDescriptionWelsh": "Colofn llywio:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6256,6 +6888,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "couple clamp bolt or locking device missing or loose.",
+            "deficiencyTextWelsh": "bollt clamp cwpl neu ddyfais cloi ar goll neu'n rhydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6265,6 +6898,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with excessive movement of centre of steering wheel in line with the column (end float).",
+            "deficiencyTextWelsh": "gyda symudiad gormodol o ganol y llyw yn unol â'r golofn (fflôt diwedd).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6274,6 +6908,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with excessive side play indicating a badly worn top bearing or insecure top mounting bracket.",
+            "deficiencyTextWelsh": "gyda chwarae ochr gormodol yn dynodi dwyn top sydd wedi treulio'n wael neu fraced mowntio top ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6283,6 +6918,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "flexible coupling or universal joint insecure, deteriorated or with excessive wear.",
+            "deficiencyTextWelsh": "cyplu hyblyg neu gymal cyffredinol yn ansicr, wedi dirywio neu â thraul gormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6292,6 +6928,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "coupling clamp bolt or locking device missing or loose with a serious risk of separation.",
+            "deficiencyTextWelsh": "bollt clamp cyplu neu ddyfais cloi ar goll neu'n rhydd gyda risg difrifol o wahanu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6301,6 +6938,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with an adjustment device worn to such an extent that it would render the column insecure.",
+            "deficiencyTextWelsh": "gyda dyfais addasu wedi'i gwisgo i'r fath raddau fel y byddai'n gwneud y golofn yn ansicr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6310,6 +6948,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with an adjustment device worn to such an extent that it would render the column insecure with a serious risk of loss of steering control.",
+            "deficiencyTextWelsh": "gyda dyfais addasu wedi'i gwisgo i'r fath raddau fel y byddai'n gwneud y golofn yn ansefydlog gyda risg difrifol o golli rheolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6319,6 +6958,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with an inappropriate modification.",
+            "deficiencyTextWelsh": "gydag addasiad amhriodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6328,6 +6968,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with an unsafe modification which has seriously weakened the component, does not provide sufficient clearance to other vehicle parts or affects the steering function.",
+            "deficiencyTextWelsh": "gydag addasiad anniogel sydd wedi gwanhau'r gydran yn ddifrifol, nad yw'n darparu digon o gliriad i rannau eraill y cerbyd nac yn effeithio ar y swyddogaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6336,6 +6977,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Steering Wheel:",
+        "itemDescriptionWelsh": "Olwyn llywio:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6344,6 +6986,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6353,6 +6996,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6362,6 +7006,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "hub, spoke or rim fractured or cracked.",
+            "deficiencyTextWelsh": "canolbwynt, adain neu ymyl wedi torri neu wedi cracio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6371,6 +7016,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "hub, spoke or rim fractured or cracked to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "canolbwynt, adain neu ymyl wedi torri neu wedi cracio i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6380,6 +7026,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cover torn with jagged edges likely to injure the driver.",
+            "deficiencyTextWelsh": "gorchudd wedi'i rwygo ag ymylon miniog sy'n debygol o anafu'r gyrrwr.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6389,6 +7036,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "hub retaining device not fitted or loose.",
+            "deficiencyTextWelsh": "dyfais cadw canolbwynt heb ei ffitio neu'n rhydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6398,6 +7046,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "hub retaining device not fitted or loose and detachment is likely.",
+            "deficiencyTextWelsh": "dyfais cadw canolbwynt heb ei ffitio neu'n rhydd ac mae datgysylltiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6407,6 +7056,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "locking mechanism not functioning correctly.",
+            "deficiencyTextWelsh": "mecanwaith cloi ddim yn gweithio'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6416,6 +7066,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "locking mechanism not functioning correctly and affects safe steering operation.",
+            "deficiencyTextWelsh": "mecanwaith cloi ddim yn gweithio'n gywir ac yn effeithio ar weithrediad llywio diogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6424,6 +7075,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Free play in system",
+        "itemDescriptionWelsh": "Chwarae rhydd yn y system",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6432,6 +7084,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "which is outside the prescribed limits.",
+            "deficiencyTextWelsh": "sydd y tu allan i'r terfynau rhagnodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6441,6 +7094,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "which is outside the prescribed limits obviously effecting safe control of the vehicle.",
+            "deficiencyTextWelsh": "sydd y tu allan i'r terfynau rhagnodedig yn amlwg yn effeithio ar reolaeth ddiogel y cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6452,6 +7106,7 @@
     "id": 35,
     "imNumber": 33,
     "imDescription": "Speed Limiter",
+    "imDescriptionWelsh": "Cyfyngydd Cyflymder",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -6484,6 +7139,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Set Speed marked on Speed Limiter Plate greater than:",
+        "itemDescriptionWelsh": "Gosod Cyflymder wedi'i farcio ar Blât Cyfyngu Cyflymder sy'n fwy na:",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -6492,6 +7148,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "90km/h (56 mph) for a vehicle described in Application section Groups A, C, D, E & F.",
+            "deficiencyTextWelsh": "90km/a (56 mya) ar gyfer cerbyd a ddisgrifir yn adran Cais Grwpiau A, C, D, E & F.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -6501,6 +7158,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "96.5 km/h (60 mph) for a vehicle described in Application section Group B.",
+            "deficiencyTextWelsh": "96.5km/a (60 mya) ar gyfer cerbyd a ddisgrifir yn adran Cais Grwp B.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -6509,6 +7167,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Speed Limiter Plate:",
+        "itemDescriptionWelsh": "Plât Cyfyngu Cyflymder:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6517,6 +7176,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6526,6 +7186,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6535,6 +7196,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "not in a conspicuous position.",
+            "deficiencyTextWelsh": "ddim mewn safle amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6544,6 +7206,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not clearly and indelibly marked with the set speed.",
+            "deficiencyTextWelsh": "heb ei farcio'n glir ac yn annileadwy gyda'r cyflymder gosod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6552,6 +7215,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Speed Limiter:",
+        "itemDescriptionWelsh": "Cyfyngydd Cyflymder:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6560,6 +7224,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted or obviously inoperative.",
+            "deficiencyTextWelsh": "heb ei ffitio neu'n amlwg yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6569,6 +7234,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6578,6 +7244,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "actuating rods/cables disconnected or damaged so that the operation is obviously affected.",
+            "deficiencyTextWelsh": "rhodenni/ceblau actio wedi'u datgysylltu neu eu difrodi fel ei fod yn amlwg yn effeithio ar y weithred.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6587,6 +7254,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "wiring disconnected or can easily be disconnected by unauthorised means.",
+            "deficiencyTextWelsh": "gwifrau wedi'u datgysylltu neu gellir eu datgysylltu'n hawdd trwy ddulliau anawdurdodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6596,6 +7264,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tamperproof device missing or defective or showing obvious signs of interference.",
+            "deficiencyTextWelsh": "dyfais atal ymyrryd ar goll neu'n ddiffygiol neu'n dangos arwyddion amlwg o ymyrraeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6604,6 +7273,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Set Speed marked on Speed Limiter Plate greater than:",
+        "itemDescriptionWelsh": "Gosod Cyflymder wedi'i farcio ar Blât Cyfyngu Cyflymder sy'n fwy na:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -6612,6 +7282,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "70mph (113 km/h) for a vehicle described in paragraph A in the Applications section.",
+            "deficiencyTextWelsh": "70mya (113 km/h) ar gyfer cerbyd a ddisgrifir ym mharagraff A yn yr adran Ceisiadau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -6621,6 +7292,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "100 km/h (62.14 mph) for a vehicle described in paragraph B, C, D, E, F, G & H in the Application section.",
+            "deficiencyTextWelsh": "100 km/awr (62.14 mya) ar gyfer cerbyd a ddisgrifir ym mharagraffau B, C, D, E, F, G & H yn yr adran Ceisiadau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -6632,6 +7304,7 @@
     "id": 36,
     "imNumber": 34,
     "imDescription": "Pressure/Vacuum Warning and Build Up",
+    "imDescriptionWelsh": "Rhybudd Pwysau/Gwactod a Chrynodiad",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -6664,6 +7337,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Time to reach minimum effective working pressure",
+        "itemDescriptionWelsh": "Amser i gyrraedd y pwysau gweithio effeithiol lleiaf",
         "forVehicleType": ["hgv"],
         "deficiencies": [
           {
@@ -6672,6 +7346,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is more than 3 minutes for pressure systems and 1 minute for vacuum systems (6 minutes for type approved vehicles designed to draw a trailer).",
+            "deficiencyTextWelsh": "yn fwy na 3 munud ar gyfer systemau gwasgedd ac 1 munud ar gyfer systemau gwactod (6 munud ar gyfer cerbydau math cymeradwy sydd wedi'u cynllunio i dynnu trelar).",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -6680,6 +7355,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Time to reach minimum effective working pressure",
+        "itemDescriptionWelsh": "Amser i gyrraedd y pwysau gweithio effeithiol lleiaf",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -6688,6 +7364,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is more than 3 minutes for pressure systems and 1 minute for vacuum systems.",
+            "deficiencyTextWelsh": "yn fwy na 3 munud ar gyfer systemau gwasgedd ac 1 munud ar gyfer systemau gwactod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -6696,6 +7373,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A mandatory visual warning device:",
+        "itemDescriptionWelsh": "Dyfais rhybudd gweledol gorfodol:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6704,6 +7382,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cannot be seen by the driver in all lighting conditions or heard as applicable.",
+            "deficiencyTextWelsh": "na all y gyrrwr ei weld o dan yr holl amodau goleuo na'i glywed fel sy'n berthnasol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6713,6 +7392,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted or not working correctly.",
+            "deficiencyTextWelsh": "heb ei ffitio neu ddim yn gweithio'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6721,6 +7401,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Not enough pressure or vacuum",
+        "itemDescriptionWelsh": "Dim digon o bwysau na gwactod",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6729,6 +7410,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "to give at least four fully assisted brake applications after the warning device has indicated minimum effective working conditions.",
+            "deficiencyTextWelsh": "i roi o leiaf pedwar cymhwysiad brêc â chymorth llawn ar ôl i'r ddyfais rhybuddio nodi amodau gwaith lleiaf effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6738,6 +7420,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "to give at least two fully assisted brake applications after the warning device has indicated minimum effective working conditions.",
+            "deficiencyTextWelsh": "i roi o leiaf dau cymhwysiad brêc â chymorth llawn ar ôl i'r ddyfais rhybuddio nodi amodau gwaith lleiaf effeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6749,6 +7432,7 @@
     "id": 37,
     "imNumber": 36,
     "imDescription": "Hand Lever Operating Mechanical Brakes and Electronic Park brake Control",
+    "imDescriptionWelsh": "Breciau Mecanyddol Gweithredu Lifer Llaw a Rheoli brêc Parcio Electronig",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -6781,6 +7465,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Brake lever:",
+        "itemDescriptionWelsh": "Lifer brêcio:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6789,6 +7474,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fractured or cracked.",
+            "deficiencyTextWelsh": "wedi torri neu wedi cracio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6798,6 +7484,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "excessively corroded.",
+            "deficiencyTextWelsh": "wedi cyrydu’n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6807,6 +7494,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6816,6 +7504,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "so positioned that it cannot be operated satisfactorily.",
+            "deficiencyTextWelsh": "mewn sefyllfa felly fel na ellir ei weithredu'n foddhaol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6825,6 +7514,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "impeded in its travel.",
+            "deficiencyTextWelsh": "rhwystredig yn ei deithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6834,6 +7524,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is not held in the “on” position when knocked.",
+            "deficiencyTextWelsh": "ddim yn cael ei ddal yn y safle “ymlaen” pan gaiff ei fwrw.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6843,6 +7534,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "excessive or insufficient reserve travel.",
+            "deficiencyTextWelsh": "teithio gormodol neu annigonol wrth gefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6852,6 +7544,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pivot with side play such that it is likely to fail.",
+            "deficiencyTextWelsh": "colyn gyda chwarae ochr fel ei fod yn debygol o fethu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6861,6 +7554,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pivot is tight in operation.",
+            "deficiencyTextWelsh": "colyn yn dynn ar waith.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6870,6 +7564,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "does not release correctly.",
+            "deficiencyTextWelsh": "ddim yn rhyddhau'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6879,6 +7574,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "does not release correctly and is functionally affected.",
+            "deficiencyTextWelsh": "nad yw'n rhyddhau'n gywir ac yn cael ei effeithio'n swyddogaethol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6887,6 +7583,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Pawl mechanism:",
+        "itemDescriptionWelsh": "Mecanwaith atalfar:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6895,6 +7592,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "and/or mountings in such a condition that early failure is likely.",
+            "deficiencyTextWelsh": "a/neu osodiadau yn y fath gyflwr fel bod methiant cynnar yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6904,6 +7602,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pawl spring is not pushing teeth into positive engagement with ratchet teeth.",
+            "deficiencyTextWelsh": "nid yw hongiad atalfar yn gwthio dannedd i ymgysylltu cadarnhaol â dannedd clicied.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6912,6 +7611,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Locking and/or retaining devices",
+        "itemDescriptionWelsh": "Cloi a/neu gadw dyfeisiau",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6920,6 +7620,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing or insecure.",
+            "deficiencyTextWelsh": "ar goll neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6928,6 +7629,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Electronic Park Brake control:",
+        "itemDescriptionWelsh": "Rheolaeth Brêc Parcio Electronig:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -6936,6 +7638,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "activator missing, damaged or inoperative.",
+            "deficiencyTextWelsh": "actifydd ar goll, wedi'i ddifrodi neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -6945,6 +7648,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incorrect functionality, warning indicator shows malfunction.",
+            "deficiencyTextWelsh": "ymarferoldeb anghywir, dangosydd rhybudd yn dangos camweithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -6956,6 +7660,7 @@
     "id": 38,
     "imNumber": 37,
     "imDescription": "Service Brake Pedal",
+    "imDescriptionWelsh": "Pedal Brêc Gwasanaeth",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -6988,6 +7693,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Brake pedal or assembly:",
+        "itemDescriptionWelsh": "Pedal brêc neu gydosod:",
         "forVehicleType": ["hgv", "psv"],
         "deficiencies": [
           {
@@ -6996,6 +7702,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "capable of applying each side of the vehicles brakes independently and the assembly is unlocked.",
+            "deficiencyTextWelsh": "yn gallu gosod breciau bob ochr i'r cerbyd yn annibynnol ac mae'r cynulliad wedi'i ddatgloi.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -7005,6 +7712,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, incomplete, fractured, cracked, or corroded and is functionality affected.",
+            "deficiencyTextWelsh": "yn ansefydlog, yn anghyflawn, wedi hollti, wedi cracio, neu wedi rhydu ac a effeithir ar ymarferoldeb.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7014,6 +7722,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pivot is tight in operation.",
+            "deficiencyTextWelsh": "colyn yn dynn ar waith.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7023,6 +7732,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "does not release correctly.",
+            "deficiencyTextWelsh": "ddim yn rhyddhau'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7032,6 +7742,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "does not release correctly and functionality is affected.",
+            "deficiencyTextWelsh": "nid yw'n rhyddhau'n gywir ac effeithir ar ymarferoldeb.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -7040,6 +7751,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Brake pedal:",
+        "itemDescriptionWelsh": "Pedal brêc:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -7048,6 +7760,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "anti-slip provision missing, loose, incomplete or ineffective.",
+            "deficiencyTextWelsh": "darpariaeth gwrthlithro ar goll, yn rhydd, yn anghyflawn neu'n aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7057,6 +7770,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "has excessive side play.",
+            "deficiencyTextWelsh": "gyda chwarae gormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7066,6 +7780,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fouling other parts of the vehicle and is functionality affected.",
+            "deficiencyTextWelsh": "baeddu rhannau eraill o'r cerbyd ac a effeithir ar ymarferoldeb.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7075,6 +7790,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insufficient reserve travel when fully depressed.",
+            "deficiencyTextWelsh": "dim digon o deithio wrth gefn pan fydd yn hollol ddirwasgedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -7086,6 +7802,7 @@
     "id": 39,
     "imNumber": 38,
     "imDescription": "Service Brake Operation",
+    "imDescriptionWelsh": "Gweithrediad Brake Gwasanaeth",
     "forVehicleType": ["trl", "hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -7129,6 +7846,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Vehicles and Trailers fitted with ABS or ABS/EBS or ESC:",
+        "itemDescriptionWelsh": "Cerbydau a threlars wedi'u ffitio ag ABS neu ABS/EBS neu ESC:",
         "forVehicleType": ["trl", "hgv"],
         "deficiencies": [
           {
@@ -7137,6 +7855,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an ESC system switch insecure or faulty or which does not allow automatic resetting of the ESC function to “on” at system energisation.",
+            "deficiencyTextWelsh": "switsh system ESC yn anniogel neu'n ddiffygiol neu nad yw'n caniatáu ailosod swyddogaeth ESC yn awtomatig i “ymlaen” adeg egnïo'r system. ",
             "stdForProhibition": false,
             "forVehicleType": ["trl"]
           },
@@ -7146,6 +7865,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a system component obviously missing or excessively damaged.",
+            "deficiencyTextWelsh": "cydran system yn amlwg ar goll neu wedi'i difrodi'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -7155,6 +7875,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "system wiring excessively damaged.",
+            "deficiencyTextWelsh": "gwifrau system wedi'u difrodi'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -7164,6 +7885,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a system component with an inappropriate modification.",
+            "deficiencyTextWelsh": "cydran system ag addasiad amhriodol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -7173,6 +7895,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a system component with an unsafe modification which has seriously weakened the component, does not provide sufficient clearance to other vehicle parts or renders the component inoperative.",
+            "deficiencyTextWelsh": "nid yw cydran system ag addasiad anniogel sydd wedi gwanhau'r gydran yn ddifrifol, yn darparu cliriad digonol i rannau eraill o'r cerbyd neu'n gwneud y gydran yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -7182,6 +7905,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an ESC system switch insecure or faulty or which does not allow automatic resetting of the ESC function to “on” at system energisation.",
+            "deficiencyTextWelsh": "switsh system ESC yn anniogel neu'n ddiffygiol neu nad yw'n caniatáu ailosod swyddogaeth ESC yn awtomatig i “ymlaen” adeg egnïo'r system. ",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           }
@@ -7190,6 +7914,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "On vehicles and trailers both fitted with ISO 7638 (ABS/EBS) lead sockets",
+        "itemDescriptionWelsh": "Ar gerbydau a trelars, y ddau wedi'u gosod â socedi plwm ISO 7638 (ABS/EBS).",
         "forVehicleType": ["hgv", "psv", "trl"],
         "deficiencies": [
           {
@@ -7198,6 +7923,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an ISO 7638 connecting lead not fitted or being used.",
+            "deficiencyTextWelsh": "plwm cysylltu ISO 7638 heb ei osod neu ei ddefnyddio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -7207,6 +7933,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an ISO 7638 connecting lead not fitted or being used.",
+            "deficiencyTextWelsh": "plwm cysylltu ISO 7638 heb ei osod neu ei ddefnyddio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "trl"]
           }
@@ -7215,6 +7942,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "A mandatory ABS system",
+        "itemDescriptionWelsh": "System ABS orfodol",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -7223,6 +7951,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted to a vehicle or trailer where it is a mandatory requirement.",
+            "deficiencyTextWelsh": "heb ei osod ar gerbyd lle mae'n ofyniad gorfodol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -7231,6 +7960,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Vehicles fitted with ABS or ABS/EBS or ESC:",
+        "itemDescriptionWelsh": "Cerbydau wedi'u ffitio ag ABS neu ABS/EBS neu ESC:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -7239,6 +7969,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a system component obviously missing or excessively damaged.",
+            "deficiencyTextWelsh": "cydran system yn amlwg ar goll neu wedi'i difrodi'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7248,6 +7979,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "system wiring excessively damaged.",
+            "deficiencyTextWelsh": "gwifrau system wedi'u difrodi'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7257,6 +7989,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a system component with an inappropriate modification.",
+            "deficiencyTextWelsh": "cydran system ag addasiad amhriodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7266,6 +7999,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a system component with an unsafe modification which has seriously weakened the component, does not provide sufficient clearance to other vehicle parts or renders the component inoperative.",
+            "deficiencyTextWelsh": "nid yw cydran system ag addasiad anniogel sydd wedi gwanhau'r gydran yn ddifrifol, yn darparu cliriad digonol i rannau eraill o'r cerbyd neu'n gwneud y gydran yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7275,6 +8009,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an ESC system switch insecure or faulty or which does not allow automatic resetting of the ESC function to “on” at system energisation.",
+            "deficiencyTextWelsh": "switsh system ESC yn anniogel neu'n ddiffygiol neu nad yw'n caniatáu ailosod swyddogaeth ESC yn awtomatig i “ymlaen” adeg egnïo'r system. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -7283,6 +8018,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "A mandatory ABS system",
+        "itemDescriptionWelsh": "System ABS orfodol",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -7291,6 +8027,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not fitted to a vehicle where it is a mandatory requirement.",
+            "deficiencyTextWelsh": "heb ei osod ar gerbyd lle mae'n ofyniad gorfodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -7299,6 +8036,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Air pressure or vacuum systems gauge reading",
+        "itemDescriptionWelsh": "Darlleniad mesurydd pwysedd aer neu systemau gwactod",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -7307,6 +8045,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "drops when pedal depressed indicating a leak in the system.",
+            "deficiencyTextWelsh": "yn disgyn pan fydd y pedal yn ddirwasgedig sy'n dangos bod y system yn gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -7315,6 +8054,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Hydraulic systems (other than full power systems):",
+        "itemDescriptionWelsh": "Systemau hydrolig (ac eithrio systemau pŵer llawn):",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -7323,6 +8063,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pedal creeps down to the floor when depressed.",
+            "deficiencyTextWelsh": "pedal yn cripian i lawr i'r llawr pan yn isel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7332,6 +8073,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "sponginess when pedal depressed.",
+            "deficiencyTextWelsh": "sbyngrwydd pan fydd pedal yn isel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -7340,6 +8082,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Servo unit",
+        "itemDescriptionWelsh": "Uned Servo",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -7348,6 +8091,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "defective or ineffective.",
+            "deficiencyTextWelsh": "diffygiol neu aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7357,6 +8101,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "does not dip when engine started, indicating lack of assistance for brake systems assisted by engine vacuum.",
+            "deficiencyTextWelsh": "nad yw'n dipio pan ddechreuodd yr injan, gan ddangos diffyg cymorth ar gyfer systemau brêc gyda chymorth gwactod injan.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -7365,6 +8110,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Full pressure hydraulic system",
+        "itemDescriptionWelsh": "System hydrolig pwysedd llawn",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -7373,6 +8119,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "pressure is not maintained for 10 minutes when the brakes are off and the engine is stopped.",
+            "deficiencyTextWelsh": "ni chynhelir pwysau am 10 munud pan fydd y breciau i ffwrdd a'r injan yn cael ei stopio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -7381,6 +8128,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Any of the required ABS or ABS/EBS or ESC warning lamps:",
+        "itemDescriptionWelsh": "Unrhyw un o'r lampau rhybuddio ABS neu ABS / EBS neu ESC gofynnol:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7389,6 +8137,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "are missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7398,6 +8147,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "do not illuminate as required when ignition switched on.",
+            "deficiencyTextWelsh": "ddim yn goleuo yn ôl yr angen pan fydd y taniad ymlaen.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7407,6 +8157,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "indicate a fault.",
+            "deficiencyTextWelsh": "nodi nam.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -7418,6 +8169,7 @@
     "id": 40,
     "imNumber": 39,
     "imDescription": "Hand Operated Brake Control Valves",
+    "imDescriptionWelsh": "Falfiau Rheoli Brêc a Weithredir â Llaw",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -7461,6 +8213,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Control valve:",
+        "itemDescriptionWelsh": "Falf rheoli:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7469,6 +8222,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "on a motor vehicle unable to be operated from the driving position.",
+            "deficiencyTextWelsh": "ar gerbyd modur na ellir ei weithredu o'r safle gyrru.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -7478,6 +8232,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7487,6 +8242,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fractured, cracked, damaged or excessively corroded.",
+            "deficiencyTextWelsh": "wedi torri, cracio, difrodi neu wedi rhydu'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7496,6 +8252,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "impeded in its travel.",
+            "deficiencyTextWelsh": "rhwystredig yn ei deithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7505,6 +8262,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "leaking.",
+            "deficiencyTextWelsh": "yn gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7514,6 +8272,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "excessive wear in the gate or lever locating mechanism.",
+            "deficiencyTextWelsh": "traul gormodol yn y giât neu fecanwaith lleoli lifer.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7523,6 +8282,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "malfunctioning.",
+            "deficiencyTextWelsh": "camweithredu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -7534,6 +8294,7 @@
     "id": 41,
     "imNumber": 41,
     "imDescription": "Condition of Chassis",
+    "imDescriptionWelsh": "Cyflwr Siasi",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -7577,6 +8338,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any main or cross member or outrigger which has a load restraining device attached:",
+        "itemDescriptionWelsh": "Unrhyw brif aelod neu draws-aelod neu all-glicied sydd â dyfais atal llwyth ynghlwm:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -7585,6 +8347,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "fractured, cracked, corroded, or deformed.",
+            "deficiencyTextWelsh": "wedi torri, cracio, wedi cyrydu, neu wedi dadffurfio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -7594,6 +8357,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fractured, cracked, with excessive corrosion, or deformed, so that the control of the vehicle is likely to be affected or the load will become insecure.",
+            "deficiencyTextWelsh": "wedi torri, cracio, gyda gormod o gyrydiad, neu wedi'i ddadffurfio, fel bod rheolaeth y cerbyd yn debygol o gael ei effeithio neu y bydd y llwyth yn mynd yn ansefydlog.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -7602,6 +8366,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Frame and/or cross member fastenings:",
+        "itemDescriptionWelsh": "Ffrâm a/neu gaeadau traws-aelod:",
         "forVehicleType": ["hgv", "trl", "psv"],
         "deficiencies": [
           {
@@ -7610,6 +8375,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure flitch plates and/or fastenings or welds breaking away.",
+            "deficiencyTextWelsh": "platiau fflitch anniogel a/neu ffasninau neu welds yn torri i ffwrdd. ",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7619,6 +8385,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure flitch plates and/or fastenings or welds breaking away so that the control of the vehicle is likely to be affected or the load will become insecure.",
+            "deficiencyTextWelsh": "platiau fflitch anniogel a/neu ffasninau neu welds yn torri i ffwrdd fel bod rheolaeth y cerbyd yn debygol o gael ei effeithio neu y bydd y llwyth yn mynd yn ansefydlog.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -7628,6 +8395,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure flitch plates and/or fastenings or welds breaking away so that the control of the vehicle is likely to be affected.",
+            "deficiencyTextWelsh": "platiau fflitch anniogel a/neu ffasninau neu welds yn torri i ffwrdd fel bod rheolaeth y cerbyd yn debygol o gael ei effeithio. ",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -7636,6 +8404,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Integral body replacement panels:",
+        "itemDescriptionWelsh": "Paneli amnewid corff annatod:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7644,6 +8413,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "of an obviously unsuitable material.",
+            "deficiencyTextWelsh": "o ddeunydd sy'n amlwg yn anaddas.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7653,6 +8423,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "of an obviously unsuitable material and stability impaired.",
+            "deficiencyTextWelsh": "o ddeunydd sy'n amlwg yn anaddas a sefydlogrwydd wedi'i amharu.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7662,6 +8433,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "not adequately secured by an appropriate method.",
+            "deficiencyTextWelsh": "heb ei sicrhau'n ddigonol trwy ddull priodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7671,6 +8443,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "not adequately secured by an appropriate method and stability impaired.",
+            "deficiencyTextWelsh": "heb ei ddiogelu'n ddigonol gan ddull priodol a sefydlogrwydd wedi'i amharu.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -7679,6 +8452,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any main or cross member:",
+        "itemDescriptionWelsh": "Unrhyw brif aelod neu draws aelod:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -7687,6 +8461,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "fractured, cracked, corroded, or deformed.",
+            "deficiencyTextWelsh": "wedi torri, cracio, wedi cyrydu, neu wedi dadffurfio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7696,6 +8471,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fractured, cracked, with excessive corrosion, or deformed, so that the control of the vehicle is likely to be affected.",
+            "deficiencyTextWelsh": "wedi torri, cracio, gyda gormod o gyrydiad, neu wedi'i ddadffurfio, fel bod rheolaeth y cerbyd yn debygol o gael ei effeithio.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }
@@ -7707,6 +8483,7 @@
     "id": 42,
     "imNumber": 42,
     "imDescription": "Electrical Wiring and Equipment",
+    "imDescriptionWelsh": "Gwifrau Trydanol ac Offer",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -7750,6 +8527,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Wiring:",
+        "itemDescriptionWelsh": "Gwifrau:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7758,6 +8536,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "chafing, damaged or deteriorated insulation.",
+            "deficiencyTextWelsh": "insiwleiddio wedi'i ddifrodi neu wedi dirywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7767,6 +8546,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "chafed, damaged or deteriorated insulation, which is likely to cause a short circuit fault.",
+            "deficiencyTextWelsh": "inswleiddio wedi'i siapio, wedi'i ddifrodi neu wedi dirywio, sy'n debygol o achosi nam cylched byr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7776,6 +8556,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "chafed, damaged or deteriorated insulation, with obvious risk of fire.",
+            "deficiencyTextWelsh": "inswleiddio wedi'i siapio, wedi'i ddifrodi neu wedi dirywio, gyda risg amlwg o dân.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7785,6 +8566,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "not adequately secured.",
+            "deficiencyTextWelsh": "heb ei ddiogelu'n ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7794,6 +8576,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "not adequately secured with fixings touching sharp edges and or connectors likely to be disconnected.",
+            "deficiencyTextWelsh": "heb ei ddiogelu'n ddigonol gyda gosodiadau'n cyffwrdd ag ymylon miniog a/neu gysylltwyr yn debygol o gael eu datgysylltu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7803,6 +8586,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "not adequately secured and wiring likely to touch hot or rotating parts or the ground.",
+            "deficiencyTextWelsh": "heb ei ddiogelu'n ddigonol a gwifrau'n debygol o gyffwrdd â rhannau poeth neu gylchdroi neu'r llawr.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -7811,6 +8595,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Battery:",
+        "itemDescriptionWelsh": "Batri:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7819,6 +8604,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "and/or carrier insecure.",
+            "deficiencyTextWelsh": "a/neu cludwr yn ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7828,6 +8614,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "and/or carrier insecure and likely to become displaced or cause a short circuit.",
+            "deficiencyTextWelsh": "a/neu cludwr yn ansicr ac yn debygol o ddadleoli neu achosi cylched byr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7837,6 +8624,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "case leaking.",
+            "deficiencyTextWelsh": "casyn yn gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7846,6 +8634,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "switch or fuse defective.",
+            "deficiencyTextWelsh": "switsh neu ffiws yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7855,6 +8644,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "container inadequately vented.",
+            "deficiencyTextWelsh": "cynhwysydd heb ei awyru'n ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7864,6 +8654,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cell closures missing or insecure.",
+            "deficiencyTextWelsh": "cau celloedd ar goll neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -7872,6 +8663,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "A trailer electrical socket:",
+        "itemDescriptionWelsh": "Soced trydanol trelar:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7880,6 +8672,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7889,6 +8682,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure and likely to become detached.",
+            "deficiencyTextWelsh": "ansefydlog ac yn debygol o ddatgysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7898,6 +8692,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "damaged or deteriorated.",
+            "deficiencyTextWelsh": "wedi difrodi neu ddirywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7907,6 +8702,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "damaged or deteriorated to the extent that the connecting lead cannot be securely connected.",
+            "deficiencyTextWelsh": "wedi difrodi neu ddirywio i'r graddau na all y plwm cysylltu gael ei gysylltu'n ddiogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -7915,6 +8711,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "A power train:",
+        "itemDescriptionWelsh": "Trên pŵer:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -7923,6 +8720,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -7932,6 +8730,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "presents a risk of fire or injury.",
+            "deficiencyTextWelsh": "yn cyflwyno risg o dân neu anaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -7940,6 +8739,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Circuits of over 100 volts are not:",
+        "itemDescriptionWelsh": "Nid yw cylchedau dros 100 folt:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -7948,6 +8748,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "protected by double pole switches or isolating switches.",
+            "deficiencyTextWelsh": "wedi'u hamddiffyn gan switshis polyn dwbl neu switshis ynysu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7957,6 +8758,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "situated inside the vehicle.",
+            "deficiencyTextWelsh": "wedi'u lleoli y tu mewn i'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -7966,6 +8768,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "accessible to the driver or crew.",
+            "deficiencyTextWelsh": "yn hygyrch i'r gyrrwr neu'r criw.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -7974,6 +8777,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Television receiver",
+        "itemDescriptionWelsh": "Derbynnydd teledu",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -7982,6 +8786,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "visible to the driver whilst driving.",
+            "deficiencyTextWelsh": "yn weladwy i'r gyrrwr wrth yrru.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -7990,6 +8795,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "Ignition or charging system",
+        "itemDescriptionWelsh": "System danio neu wefru",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -7998,6 +8804,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "not adequately suppressed.",
+            "deficiencyTextWelsh": "heb ei atal yn ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8009,6 +8816,7 @@
     "id": 43,
     "imNumber": 43,
     "imDescription": "Engine and Transmission Mountings",
+    "imDescriptionWelsh": "Mowntiau Injan a Throsglwyddo",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -8041,6 +8849,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any mounting or subframe:",
+        "itemDescriptionWelsh": "Unrhyw fowntio neu is-ffrâm:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -8049,6 +8858,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "securing nuts/bolts loose or missing.",
+            "deficiencyTextWelsh": "sicrhau cnau/bolltau yn rhydd neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8058,6 +8868,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "securing nut/bolts loose or missing to such an extent that road safety is endangered.",
+            "deficiencyTextWelsh": "sicrhau cneuen/bolltau yn rhydd neu ar goll i'r fath raddau fel bod diogelwch ar y ffyrdd mewn perygl.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8067,6 +8878,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "cracked or fractured.",
+            "deficiencyTextWelsh": "wedi cracio neu wedi torri.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8076,6 +8888,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "cracked or fractured to such an extent that road safety is endangered.",
+            "deficiencyTextWelsh": "wedi cracio neu wedi torri i'r fath raddau fel bod diogelwch ar y ffyrdd mewn perygl.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8085,6 +8898,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "badly deteriorated.",
+            "deficiencyTextWelsh": "wedi dirywio'n ddrwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8094,6 +8908,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "badly deteriorated to such an extent that road safety is endangered.",
+            "deficiencyTextWelsh": "wedi dirywio'n wael i'r fath raddau fel bod diogelwch ar y ffyrdd mewn perygl.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -8105,6 +8920,7 @@
     "id": 44,
     "imNumber": 44,
     "imDescription": "Oil and Waste Leaks",
+    "imDescriptionWelsh": "Gollyngiadau Olew a Gwastraff",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -8148,6 +8964,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any oil leak which can deposit",
+        "itemDescriptionWelsh": "Unrhyw ollyngiad olew a all adneuo",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -8156,6 +8973,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "oil at a rate in excess of a 75mm diameter pool in 5 minutes or a number of leaks which collectively would deposit oil in excess of this.",
+            "deficiencyTextWelsh": "olew ar gyfradd uwch na phwll diamedr 75mm mewn 5 munud neu nifer o ollyngiadau a fyddai gyda'i gilydd yn dyddodi olew sy'n fwy na hyn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8165,6 +8983,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "oil in a continuous flow or constitutes a serious risk of fire.",
+            "deficiencyTextWelsh": "olew mewn llif di-dor neu yn golygu risg difrifol o dân.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8173,6 +8992,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Leakage of waste which",
+        "itemDescriptionWelsh": "Gollyngiad o wastraff sydd",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -8181,6 +9001,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is likely to cause unpleasant or dangerous conditions for other road users or damage road surfaces.",
+            "deficiencyTextWelsh": "yn debygol o achosi amodau annymunol neu beryglus i ddefnyddwyr eraill y ffordd neu niweidio arwynebau ffyrdd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8189,6 +9010,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Leakages which when the vehicle is in motion,",
+        "itemDescriptionWelsh": "Gollyngiadau sydd pan fydd y cerbyd yn symud,",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -8197,6 +9019,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "can heavily contaminate the vehicle such that it causes a health or fire risk.",
+            "deficiencyTextWelsh": "yn gallu halogi'r cerbyd yn drwm fel ei fod yn achosi risg i iechyd neu dân.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8205,6 +9028,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any oil leak which can deposit",
+        "itemDescriptionWelsh": "Unrhyw ollyngiad olew a all adneuo",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -8213,6 +9037,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "oil at a rate in excess of a 75mm diameter pool in 5 minutes or a number of leaks which collectively would deposit oil in excess of this.",
+            "deficiencyTextWelsh": "olew ar gyfradd uwch na phwll diamedr 75mm mewn 5 munud neu nifer o ollyngiadau a fyddai gyda'i gilydd yn dyddodi olew sy'n fwy na hyn.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -8222,6 +9047,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "oil in a continuous flow or constitutes a serious risk of fire.",
+            "deficiencyTextWelsh": "olew mewn llif di-dor neu yn golygu risg difrifol o dân.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -8233,6 +9059,7 @@
     "id": 45,
     "imNumber": 45,
     "imDescription": "Fuel Tanks and System",
+    "imDescriptionWelsh": "Tanciau a System Tanwydd",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -8276,6 +9103,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Fuel System:",
+        "itemDescriptionWelsh": "System Tanwydd:",
         "forVehicleType": ["hgv", "trl", "psv"],
         "deficiencies": [
           {
@@ -8284,6 +9112,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "leaking and does not represent an obvious hazard to other road users.",
+            "deficiencyTextWelsh": "gollwng ac nid yw'n berygl amlwg i ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -8293,6 +9122,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking and represents an obvious hazard to other road users.",
+            "deficiencyTextWelsh": "gollwng ac yn cynrychioli perygl amlwg i ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -8302,6 +9132,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "pipes damaged (restricted/chafed) or so positioned that they are fouled by moving parts of the vehicle.",
+            "deficiencyTextWelsh": "pibellau wedi'u difrodi (cyfyngedig/rhif) neu wedi'u gosod fel eu bod yn cael eu baeddu gan rannau symudol o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8311,6 +9142,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "pipes so damaged (restricted/chafed), insecure or with an inadequate repair, such that they are likely to fail and leak which would cause danger to persons on the vehicle or to other road users.",
+            "deficiencyTextWelsh": "pibellau sydd wedi'u difrodi cymaint (cyfyngedig/rhathu), anniogel neu wedi'u trwsio'n annigonol, fel eu bod yn debygol o fethu a gollwng a fyddai'n achosi perygl i bobl ar y cerbyd neu i ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8320,6 +9152,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "leaking and does not represent an obvious hazard to other road users or passengers.",
+            "deficiencyTextWelsh": "gollwng ac nid yw'n berygl amlwg i ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8329,6 +9162,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking and represents an obvious hazard to other road users or passengers.",
+            "deficiencyTextWelsh": "gollwng ac yn cynrychioli perygl amlwg i ddefnyddwyr eraill y ffordd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8338,6 +9172,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a pipe or pipes immediately adjacent to or in contact with electrical wiring.",
+            "deficiencyTextWelsh": "gyda phibell neu bibellau yn union gerllaw neu mewn cysylltiad â gwifrau trydanol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8347,6 +9182,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "carburettor driptray and/or drain pipe missing",
+            "deficiencyTextWelsh": "hambwrdd diferion carbwradur a/neu bibell ddraenio ar goll",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8355,6 +9191,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Fuel tank:",
+        "itemDescriptionWelsh": "Tanc tanwydd:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -8363,6 +9200,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "strap or support broken or missing.",
+            "deficiencyTextWelsh": "strap neu gefnogaeth wedi torri neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8372,6 +9210,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure on its mountings that it is likely to drop away partially or completely when the vehicle is used.",
+            "deficiencyTextWelsh": "mor ansicr ar ei fowntiau fel ei fod yn debygol o ollwng yn rhannol neu'n gyfan gwbl pan ddefnyddir y cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8381,6 +9220,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "heat shield missing, or defective to such an extent it constitutes an obvious fire risk.",
+            "deficiencyTextWelsh": "amddiffynnwr gwres ar goll, neu ddiffygiol i'r fath raddau ei fod yn gyfystyr â risg tân amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8390,6 +9230,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "defective such that leakage of fuel is possible.",
+            "deficiencyTextWelsh": "diffygiol fel bod tanwydd yn gollwng yn bosibl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -8398,6 +9239,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Filler Cap:",
+        "itemDescriptionWelsh": "Cap llenwi:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -8406,6 +9248,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8415,6 +9258,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not fasten securely by a positive means, or such that pressure is not maintained on the sealing arrangement.",
+            "deficiencyTextWelsh": "ddim yn cau'n ddiogel trwy ddull positif, neu fel na fydd pwysau'n cael ei gynnal ar y trefniant selio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8424,6 +9268,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "sealing washer torn, deteriorated or missing, or a mounting flange/sealing method defective such that leakage of fuel is possible.",
+            "deficiencyTextWelsh": "golchwr selio wedi'i rwygo, wedi dirywio neu ar goll, neu fflans mowntio/dull selio yn ddiffygiol fel bod gollwng tanwydd yn bosibl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -8435,6 +9280,7 @@
     "id": 46,
     "imNumber": 46,
     "imDescription": "Exhaust Systems and Nuisance",
+    "imDescriptionWelsh": "Systemau gwacáu a Niwsans",
     "forVehicleType": ["hgv", "psv"],
     "additionalInfo": {
       "psv": {
@@ -8467,6 +9313,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "An exhaust system:",
+        "itemDescriptionWelsh": "System gwacáu:",
         "forVehicleType": ["hgv", "psv"],
         "deficiencies": [
           {
@@ -8475,6 +9322,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "incorrectly positioned so that fumes are likely to enter the driver’s cab.",
+            "deficiencyTextWelsh": "mewn lleoliad anghywir fel bod mygdarth yn debygol o fynd i mewn i gab y gyrrwr.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -8484,6 +9332,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "positioned such that fumes are entering the driver’s cab.",
+            "deficiencyTextWelsh": "wedi'u lleoli fel bod mygdarth yn mynd i mewn i gab y gyrrwr.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -8493,6 +9342,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure but unlikely to fall away partially or completely from the vehicle.",
+            "deficiencyTextWelsh": "yn ansicr ond yn annhebygol o ddisgyn i ffwrdd yn rhannol neu'n gyfan gwbl o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8502,6 +9352,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so insecure that it might fall away partially or completely when the vehicle is in use.",
+            "deficiencyTextWelsh": "mor ansicr fel y gallai syrthio i ffwrdd yn rhannol neu'n gyfan gwbl pan fydd y cerbyd yn cael ei ddefnyddio.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8511,6 +9362,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "leaking.",
+            "deficiencyTextWelsh": "yn gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8520,6 +9372,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking and entering the drivers cab.",
+            "deficiencyTextWelsh": "gollwng a mynd i mewn i gab y gyrrwr.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv"]
           },
@@ -8529,6 +9382,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking and entering the drivers cab and/or passenger compartment.",
+            "deficiencyTextWelsh": "gollwng a mynd i mewn i gab y gyrrwr a/neu adran y teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8538,6 +9392,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "incorrectly positioned so that fumes are likely to enter the driver’s cab and/or passenger compartment.",
+            "deficiencyTextWelsh": "mewn lleoliad anghywir fel bod mygdarth yn debygol o fynd i mewn i gab y gyrrwr a/neu adran y teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8547,6 +9402,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "positioned so that fumes are entering the driver’s cab and/or passenger compartment.",
+            "deficiencyTextWelsh": "wedi’u gosod fel bod mygdarth yn mynd i mewn i gab y gyrrwr a/neu adran y teithwyr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -8556,6 +9412,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "likely to cause a fire.",
+            "deficiencyTextWelsh": "yn debygol o achosi tân.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8564,6 +9421,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "An exhaust silencer:",
+        "itemDescriptionWelsh": "Tawelwr gwacáu:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -8572,6 +9430,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing.",
+            "deficiencyTextWelsh": "ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8581,6 +9440,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "obviously ineffective.",
+            "deficiencyTextWelsh": "yn amlwg yn aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -8589,6 +9449,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Any part of the noise suppression system:",
+        "itemDescriptionWelsh": "Unrhyw ran o'r system atal sŵn:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -8597,6 +9458,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -8606,6 +9468,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "likely to become detached.",
+            "deficiencyTextWelsh": "yn debygol o ddod yn ddatgysylltiedig.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -8614,6 +9477,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Any exhaust or waste system",
+        "itemDescriptionWelsh": "Unrhyw system wacáu neu wastraff",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -8622,6 +9486,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fouling or likely to cause a fume hazard.",
+            "deficiencyTextWelsh": "baeddu neu'n debygol o achosi perygl o mygdarth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8630,6 +9495,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Missing or inadequate",
+        "itemDescriptionWelsh": "Ar goll neu'n annigonol",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -8638,6 +9504,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "grease shields to hot exhausts.",
+            "deficiencyTextWelsh": "tarianau saim i bibellau gwacáu poeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -8649,6 +9516,7 @@
     "id": 47,
     "imNumber": 48,
     "imDescription": "Suspension",
+    "imDescriptionWelsh": "Hongiad",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -8692,6 +9560,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "All suspension types - A suspension component or its attachment point:",
+        "itemDescriptionWelsh": "Pob math o hongiad - Cydran hongiad neu ei bwynt atodi:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -8700,6 +9569,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8709,6 +9579,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "ansicr i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8718,6 +9589,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "disconnected.",
+            "deficiencyTextWelsh": "wedi datgysylltu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8727,6 +9599,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fractured or cracked.",
+            "deficiencyTextWelsh": "wedi torri neu wedi cracio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8736,6 +9609,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "so damaged, worn, distorted or corroded that it adversely affects its function.",
+            "deficiencyTextWelsh": "difrodi, wedi treulio, ystumio neu gyrydu cymaint fel ei fod yn effeithio'n andwyol ar ei swyddogaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8745,6 +9619,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "so damaged, worn, distorted or corroded that it adversely affects its function and obviously affects directional stability.",
+            "deficiencyTextWelsh": "difrodi, wedi treulio, ystumio neu gyrydu cymaint fel ei fod yn effeithio'n andwyol ar ei swyddogaeth ac yn amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8754,6 +9629,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "incorrectly located or fitted or a secondary spring leaf missing.",
+            "deficiencyTextWelsh": "wedi'u lleoli neu eu gosod yn anghywir neu ddeilen sbring eilaidd ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8763,6 +9639,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a main spring leaf, multiple spring leaves or any other type of suspension spring assembly missing.",
+            "deficiencyTextWelsh": "prif ddeilen sbring, dail sbring lluosog neu unrhyw fath arall o gynulliad sbring atal ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8772,6 +9649,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "rubber or bonded bush deteriorated.",
+            "deficiencyTextWelsh": "rwber neu lwyn bondio wedi dirywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8781,6 +9659,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "defective such that a wheel could foul any other part of the vehicle or is fouling any part of the vehicle.",
+            "deficiencyTextWelsh": "diffygiol fel y gallai olwyn faeddu unrhyw ran arall o'r cerbyd neu'n baeddu unrhyw ran o'r cerbyd.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8790,6 +9669,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with wear in a spring pin, bush or mounting exceeding the prescribed limit.",
+            "deficiencyTextWelsh": "gyda treulio mewn pin sbring, llwyn neu mowntio yn fwy na'r terfyn rhagnodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8799,6 +9679,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with wear in a spring pin, bush or mounting exceeding the prescribed limit which obviously affects directional stability.",
+            "deficiencyTextWelsh": "gyda treulio mewn pin sbring, llwyn neu mowntio yn fwy na'r terfyn rhagnodedig sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8808,6 +9689,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "a ball joint dust cover deteriorated.",
+            "deficiencyTextWelsh": "dirywiad gorchudd llwch ar y cyd siâp pêl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8817,6 +9699,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "a ball joint dust cover missing, insecure, excessively damaged or severely deteriorated to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "gorchudd llwch cymal siâp pêl ar goll, yn ansefydlog, wedi'i ddifrodi'n ormodol neu wedi dirywio'n ddifrifol i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8826,6 +9709,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with a system component with an inappropriate modification.",
+            "deficiencyTextWelsh": "gyda chydran system ag addasiad amhriodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8835,6 +9719,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a system component with an unsafe modification which has seriously weakened the component, does not provide sufficient clearance to other vehicle parts or renders the suspension component inoperative.",
+            "deficiencyTextWelsh": "nid yw cydran system ag addasiad anniogel sydd wedi gwanhau'r gydran yn ddifrifol, yn darparu cliriad digonol i rannau eraill o'r cerbyd neu'n gwneud y gydran hongiad yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8844,6 +9729,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Anti-roll bar assembly missing from a vehicle on which it is a standard component or any of its associated linkage/brackets or bushes missing.",
+            "deficiencyTextWelsh": "cydosodiad bar gwrth-rhol ar goll o gerbyd y mae'n gydran safonol arno neu unrhyw un o'i ddolenni/cromfachau cysylltiedig neu lwyni ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -8852,6 +9738,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Leaf springs and fixings:",
+        "itemDescriptionWelsh": "Sbrings dail a gosodiadau:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -8860,6 +9747,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "fractured or cracked leaf or one repaired by welding.",
+            "deficiencyTextWelsh": "dail wedi torri neu gracio neu un wedi'i thrwsio trwy weldio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8869,6 +9757,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fractured or cracked leaf or one repaired by welding, which obviously affects directional stability.",
+            "deficiencyTextWelsh": "dail wedi torri neu gracio neu un wedi'i hatgyweirio gan weldio, sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8878,6 +9767,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "spring leaves splayed beyond the prescribed limits or fouling any other part of the vehicle.",
+            "deficiencyTextWelsh": "dail sbring wedi ymledu y tu hwnt i'r terfynau rhagnodedig neu'n baeddu unrhyw ran arall o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8887,6 +9777,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with excessive movement in a spring fixing pin",
+            "deficiencyTextWelsh": "gyda symudiad gormodol mewn pin gosod sbring",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8896,6 +9787,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "slipper bracket rebound pin missing or incorrectly located.",
+            "deficiencyTextWelsh": "pin adlam braced sliper ar goll neu wedi'i leoli'n anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8905,6 +9797,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "slipper bracket rebound pin missing or incorrectly located with a spring displaced.",
+            "deficiencyTextWelsh": "pin adlam braced sliper ar goll neu wedi'i leoli'n anghywir gyda sbring wedi'i ddadleoli.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8914,6 +9807,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "relative movement or displacement between a spring and the axle.",
+            "deficiencyTextWelsh": "symudiad neu ddadleoli cymharol rhwng sbring a'r echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8923,6 +9817,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "relative movement or displacement between a spring and the axle which obviously affects directional stability.",
+            "deficiencyTextWelsh": "symudiad neu ddadleoli cymharol rhwng sbring a'r echel sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8932,6 +9827,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a missing shackle or anchor pin.",
+            "deficiencyTextWelsh": "gefyn neu bin angor coll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8941,6 +9837,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a worn slipper bracket.",
+            "deficiencyTextWelsh": "braced sliper wedi treulio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8950,6 +9847,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "so corroded, pitted or seriously weakened that it is likely to fail.",
+            "deficiencyTextWelsh": "wedi rhydu, wedi'i dyllu neu wedi'i wanhau'n ddifrifol fel ei fod yn debygol o fethu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8959,6 +9857,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an insecure or missing locking device from a shackle or anchor pin.",
+            "deficiencyTextWelsh": "dyfais gloi anniogel neu ar goll o hualau neu bin angor.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -8967,6 +9866,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Coil Spring or Torsion Bar:",
+        "itemDescriptionWelsh": "Coil Sbring neu Torfar:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -8975,6 +9875,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "incomplete.",
+            "deficiencyTextWelsh": "anghyflawn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8984,6 +9885,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "incomplete and which obviously affects directional stability.",
+            "deficiencyTextWelsh": "anghyflawn ac sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -8993,6 +9895,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fractured, cracked or repaired by welding.",
+            "deficiencyTextWelsh": "wedi torri, cracio neu wedi'i thrwsio trwy weldio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9002,6 +9905,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "corroded, pitted or seriously weakened so it is likely to fail.",
+            "deficiencyTextWelsh": "wedi rhydu, wedi'i dyllu neu wedi'i wanhau'n ddifrifol fel ei fod yn debygol o fethu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9011,6 +9915,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "torsion bar fixings with excessive free play, insecure, or an adjustment assembly incorrectly fitted and/or insecurely locked.",
+            "deficiencyTextWelsh": "gosodiadau torfar gyda chwarae rhydd gormodol, anniogel, neu gydosodiad addasu wedi'i osod yn anghywir a/neu wedi'i gloi'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9020,6 +9925,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incorrectly located or fitted.",
+            "deficiencyTextWelsh": "wedi'u lleoli neu eu gosod yn anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9028,6 +9934,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Air/Fluid Suspension System Valves, pipes, Valve linkage, Bellows and Displacer/Accumulator Unit:",
+        "itemDescriptionWelsh": "Falfiau System Atal Aer/Hylif, pibellau, cyswllt falf, Meginau ac Uned Dadleoli/Cronnwr:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9036,6 +9943,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "displaced, deflated, kinked and/or so damaged/deteriorated that it likely to fail.",
+            "deficiencyTextWelsh": "wedi'i ddadleoli, wedi'i ddatchwyddo, wedi'i ginio a/neu wedi'i ddifrodi/dirywio cymaint fel ei fod yn debygol o fethu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9045,6 +9953,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "fouled by other parts.",
+            "deficiencyTextWelsh": "wedi ei faeddu gan ranau ereill.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9054,6 +9963,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a check strap missing or defective.",
+            "deficiencyTextWelsh": "gyda strap wiriad ar goll neu'n ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9063,6 +9973,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9072,6 +9983,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "leaking.",
+            "deficiencyTextWelsh": "yn gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9081,6 +9993,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking to such an extent that the function of the system is seriously affected.",
+            "deficiencyTextWelsh": "gollwng i'r fath raddau fel bod swyddogaeth y system yn cael ei effeithio'n ddifrifol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9090,6 +10003,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "system inoperable.",
+            "deficiencyTextWelsh": "system yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9098,6 +10012,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Bonded Suspension Unit:",
+        "itemDescriptionWelsh": "Uned Hongiad Bondio:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9106,6 +10021,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with failure of bonding between flexible element and metal so that part of the unit is likely to fail.",
+            "deficiencyTextWelsh": "gyda methiant bondio rhwng elfen hyblyg a metel fel bod rhan o'r uned yn debygol o fethu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9115,6 +10031,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "unit is so damaged or deteriorated that it is no longer capable of carrying out its proper function.",
+            "deficiencyTextWelsh": "uned wedi'i ddifrodi neu ddirywio cymaint fel nad yw bellach yn gallu cyflawni ei swyddogaeth briodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9123,6 +10040,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Shock Absorber:",
+        "itemDescriptionWelsh": "Amsugnwr Sioc:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9131,6 +10049,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing from a vehicle on which it is a standard component.",
+            "deficiencyTextWelsh": "ar goll o gerbyd y mae'n gydran safonol arno.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9140,6 +10059,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with an anchorage fractured, unit insecure or with a sleeve damaged so that the unit is not functioning correctly.",
+            "deficiencyTextWelsh": "gydag angorfa wedi torri, uned yn anniogel neu â llawes wedi'i difrodi fel nad yw'r uned yn gweithio'n iawn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9149,6 +10069,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "leaking.",
+            "deficiencyTextWelsh": "yn gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9158,6 +10079,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with an excessively worn rubber bush or pivot.",
+            "deficiencyTextWelsh": "gyda llwyn rwber neu golyn sydd wedi treulio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9167,6 +10089,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "linkage missing, linkage bracket cracked so that it is likely to fail, fractured or cracked or excessively worn.",
+            "deficiencyTextWelsh": "cysylltiad ar goll, braced cysylltedd wedi cracio fel ei fod yn debygol o fethu, torri asgwrn neu gracio neu dreulio gormod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9178,6 +10101,7 @@
     "id": 48,
     "imNumber": 53,
     "imDescription": "Axles, Stub Axles and Wheel Bearings",
+    "imDescriptionWelsh": "Echelau, Echelau Stwmp a Beryn Olwyn",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -9221,6 +10145,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Stub axle and axle:",
+        "itemDescriptionWelsh": "Echel stwmp ac echel:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9229,6 +10154,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessive clearance between stub axle and axle beam.",
+            "deficiencyTextWelsh": "clirio gormodol rhwng echel stwmp a thrawst echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9238,6 +10164,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessive clearance between stub axle and axle beam which obviously affects directional stability.",
+            "deficiencyTextWelsh": "clirio gormodol rhwng echel stwmp a thrawst echel sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9247,6 +10174,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "fractured, cracked or deformed.",
+            "deficiencyTextWelsh": "wedi torri, cracio neu wedi dadffurfio.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9256,6 +10184,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "inappropriate modification to an axle.",
+            "deficiencyTextWelsh": "addasiad amhriodol i echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9265,6 +10194,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "unsafe modification to an axle that obviously affects stability, functionality or gives insufficient clearance to other vehicle parts or the ground.",
+            "deficiencyTextWelsh": "addasiad anniogel i echel sy'n amlwg yn effeithio ar sefydlogrwydd, ymarferoldeb neu'n rhoi digon o gliriad i rannau eraill y cerbyd neu'r ddaear.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9273,6 +10203,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "King pin:",
+        "itemDescriptionWelsh": "Prif pin:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9281,6 +10212,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessively loose in axle beam.",
+            "deficiencyTextWelsh": "yn rhy rhydd mewn trawst echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9290,6 +10222,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessively loose in axle beam which obviously affects directional stability.",
+            "deficiencyTextWelsh": "yn rhy rhydd mewn trawst echel sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9299,6 +10232,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "king pin or bush excessively worn.",
+            "deficiencyTextWelsh": "prif pin neu lwyn wedi treulio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9308,6 +10242,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "retaining device missing or insecure.",
+            "deficiencyTextWelsh": "dyfais cadw ar goll neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9316,6 +10251,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Swivel joint:",
+        "itemDescriptionWelsh": "Cymal troi:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9324,6 +10260,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessively worn.",
+            "deficiencyTextWelsh": "wedi cael ei dreulio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9333,6 +10270,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessively worn to such an extent that directional stability is impaired.",
+            "deficiencyTextWelsh": "wedi treulio'n ormodol i'r fath raddau fel bod sefydlogrwydd cyfeiriadol yn cael ei amharu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9342,6 +10280,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9351,6 +10290,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "retaining or locking device missing or insecure.",
+            "deficiencyTextWelsh": "dyfais cadw neu gloi ar goll neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9359,6 +10299,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Wheel bearing:",
+        "itemDescriptionWelsh": "Beryn olwyn:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9367,6 +10308,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with excessive free play.",
+            "deficiencyTextWelsh": "gyda gormod o chwarae rhydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9376,6 +10318,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with excessive free play, which obviously affects directional stability.",
+            "deficiencyTextWelsh": "gyda chwarae rhydd gormodol, sy'n amlwg yn effeithio ar sefydlogrwydd cyfeiriadol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9387,6 +10330,7 @@
     "id": 49,
     "imNumber": 54,
     "imDescription": "Steering",
+    "imDescriptionWelsh": "Llywio",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -9430,6 +10374,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Power steering:",
+        "itemDescriptionWelsh": "Llywio pŵer:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9438,6 +10383,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "not working correctly.",
+            "deficiencyTextWelsh": "ddim yn gweithio'n gywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9447,6 +10393,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "not working correctly and obviously affects steering control.",
+            "deficiencyTextWelsh": "ddim yn gweithio'n gywir ac yn amlwg yn effeithio ar reolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9456,6 +10403,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "removed or disconnected when a standard fitment.",
+            "deficiencyTextWelsh": "wedi'i dynnu neu ei ddatgysylltu pan fod ffit safonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9465,6 +10413,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "removed or disconnected when a standard fitment and obviously affecting steering control.",
+            "deficiencyTextWelsh": "wedi'i dynnu neu ei ddatgysylltu pan fod ffit safonol ac yn amlwg yn effeithio ar reolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9474,6 +10423,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with an air/fluid leak from any part of the system.",
+            "deficiencyTextWelsh": "gyda gollyngiad aer/hylif o unrhyw ran o'r system.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9483,6 +10433,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "reservoir is below minimum level.",
+            "deficiencyTextWelsh": "cronfa ddŵr yn is na'r lefel isaf.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9492,6 +10443,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "reservoir is empty.",
+            "deficiencyTextWelsh": "cronfa yn wag.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9501,6 +10453,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "pump insecure or its drive system missing or defective.",
+            "deficiencyTextWelsh": "pwmp yn ansefydlog neu ei system yrru ar goll neu'n ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9510,6 +10463,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "pump insecure or its drive system missing or defective and obviously affects steering control.",
+            "deficiencyTextWelsh": "pwmp yn ansefydlog neu ei system yrru ar goll neu'n ddiffygiol ac yn amlwg yn effeithio ar reolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9519,6 +10473,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "pipe or hose excessively corroded, damaged, bulging or fouling other parts of the vehicle.",
+            "deficiencyTextWelsh": "pibell neu bibell wedi cyrydu'n ormodol, difrodi, chwyddo neu faeddu rhannau eraill o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9528,6 +10483,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "pipe or hose excessively corroded, damaged, bulging or fouling other parts of the vehicle which obviously affects steering control.",
+            "deficiencyTextWelsh": "pibell neu bibell wedi cyrydu'n ormodol, difrodi, chwyddo neu faeddu rhannau eraill o'r cerbyd sy'n amlwg yn effeithio ar reolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9537,6 +10493,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with a cracked or damaged ram and/or ram body anchorage, any excessive free play at ram anchorage.",
+            "deficiencyTextWelsh": "gyda hwrdd wedi cracio neu ddifrodi a/neu angorfa corff hwrdd, unrhyw chwarae rhydd gormodol wrth angorfa hwrdd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9546,6 +10503,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with a cracked or damaged ram and/or ram body anchorage, any excessive free play at ram anchorage, which obviously affects steering control.",
+            "deficiencyTextWelsh": "gyda hwrdd wedi cracio neu ddifrodi a/neu angorfa corff hwrdd, unrhyw chwarae rhydd gormodol wrth angorfa hwrdd, sy'n amlwg yn effeithio ar reolaeth y llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9555,6 +10513,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with excessive free play between ball and valve to the extent that separation is likely.",
+            "deficiencyTextWelsh": "gyda chwarae rhydd gormodol rhwng y bêl a'r falf i'r graddau y mae gwahanu yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9564,6 +10523,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with cables damaged, excessively corroded.",
+            "deficiencyTextWelsh": "gyda cheblau wedi'u difrodi, wedi cyrydu'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9573,6 +10533,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with cables damaged, excessively corroded to such an extent that the steering is affected.",
+            "deficiencyTextWelsh": "gyda cheblau wedi'u difrodi, wedi cyrydu'n ormodol i'r fath raddau fel bod y llywio yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9582,6 +10543,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with a system component with an inappropriate modification.",
+            "deficiencyTextWelsh": "gyda chydran system ag addasiad amhriodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9591,6 +10553,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a system component with an unsafe modification which has seriously weakened the component, does not provide sufficient clearance to other vehicle parts or renders the steering component inoperative.",
+            "deficiencyTextWelsh": "nid yw cydran system ag addasiad anniogel sydd wedi gwanhau'r gydran yn ddifrifol, yn darparu cliriad digonol i rannau eraill o'r cerbyd neu'n gwneud y gydran llywio yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9600,6 +10563,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "EPS malfunction indicator lamp indicates a fault.",
+            "deficiencyTextWelsh": "Lamp dangosydd camweithio EPS yn dynodi nam.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9608,6 +10572,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Steering with:",
+        "itemDescriptionWelsh": "Llywio gyda:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -9616,6 +10581,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a ball pin shank loose.",
+            "deficiencyTextWelsh": "garan pin bêl rhydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9625,6 +10591,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a ball pin shank loose to such an extent that separation is likely.",
+            "deficiencyTextWelsh": "pin bêl yn rhydd i'r fath raddau fel bod gwahanu yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9634,6 +10601,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a sharp or deep groove at the neck of a ball pin.",
+            "deficiencyTextWelsh": "rhigol finiog neu ddwfn wrth wddf pin bêl.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9643,6 +10611,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a track rod or drag link end insecure.",
+            "deficiencyTextWelsh": "trac rhod neu diwedd dolen lusgo ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9652,6 +10621,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a track rod or drag link end insecure to such an extent that separation is likely.",
+            "deficiencyTextWelsh": "trac rhod neu diwedd dolen lusgo ansefydlog i'r fath raddau fel bod gwahaniad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9661,6 +10631,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "any abnormal movement in a joint.",
+            "deficiencyTextWelsh": "unrhyw symudiad annormal yn y cymal.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9670,6 +10641,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "any abnormal movement in a joint to such an extent that separation is likely.",
+            "deficiencyTextWelsh": "unrhyw symudiad annormal mewn cymal i'r fath raddau fel bod gwahaniad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9679,6 +10651,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "movement between sector shaft and drop arm.",
+            "deficiencyTextWelsh": "symudiad rhwng siafft sector a braich gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9688,6 +10661,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "movement between sector shaft and drop arm to such an extent that separation is likely.",
+            "deficiencyTextWelsh": "symudiad rhwng siafft sector a braich gollwng i'r fath raddau fel bod gwahanu yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9697,6 +10671,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "excessive wear in a pivot point (e.g. an intermediate drop arm).",
+            "deficiencyTextWelsh": "traul gormodol mewn pwynt colyn (e.e. braich gollwng canolradd).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9706,6 +10681,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a component fixed to the chassis insecure.",
+            "deficiencyTextWelsh": "cydran sydd wedi'i osod ar y siasi yn ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9715,6 +10691,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a component fixed to the chassis insecure to such an extent that separation is likely.",
+            "deficiencyTextWelsh": "cydran sydd wedi'i osod ar y siasi yn anniogel i'r fath raddau fel bod gwahaniad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9724,6 +10701,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "movement between a steering arm and its fixings.",
+            "deficiencyTextWelsh": "symudiad rhwng braich llywio a'i gosodiadau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9733,6 +10711,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "movement between a steering arm and its fixings to such an extent that separation is likely.",
+            "deficiencyTextWelsh": "symudiad rhwng braich llywio a'i gosodiadau i'r fath raddau fel bod gwahaniad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9742,6 +10721,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a component fractured or so cracked, damaged, misaligned, deformed or so worn that it is likely to fail.",
+            "deficiencyTextWelsh": "cydran sydd wedi torri neu wedi cracio cymaint, wedi'i difrodi, wedi'i cham-alinio, wedi'i dadffurfio neu wedi treulio cymaint fel ei fod yn debygol o fethu.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9751,6 +10731,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a retaining or locking device ineffective, not fitted or insecure.",
+            "deficiencyTextWelsh": "dyfais cadw neu gloi yn aneffeithiol, heb ei ffitio neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9760,6 +10741,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a steering lock stop missing, insecure or not fulfilling its function.",
+            "deficiencyTextWelsh": "stop clo llywio ar goll, yn ansefydlog neu ddim yn cyflawni ei swyddogaeth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9769,6 +10751,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a component repaired by welding and or showing signs of excessive heat being applied.",
+            "deficiencyTextWelsh": "cydran wedi'i thrwsio trwy weldio a/neu sy'n dangos arwyddion o wres gormodol yn cael ei roi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9778,6 +10761,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a component repaired by welding and or showing signs of excessive heat being applied, which obviously affects the steering control.",
+            "deficiencyTextWelsh": "cydran wedi'i thrwsio trwy weldio a/neu sy'n dangos arwyddion o wres gormodol yn cael ei roi, sy'n amlwg yn effeithio ar y rheolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9787,6 +10771,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "any steering component, road wheel or tyre fouling any part of the vehicle.",
+            "deficiencyTextWelsh": "unrhyw gydran llywio, olwyn ffordd neu faw teiars unrhyw ran o'r cerbyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9796,6 +10781,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "track rod excessively deformed.",
+            "deficiencyTextWelsh": "rhod trac yn anffurfio'n ormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9805,6 +10791,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "track rod excessively deformed and obviously affects steering control.",
+            "deficiencyTextWelsh": "rhod trac yn anffurfio'n ormodol ac yn amlwg yn effeithio ar reolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9814,6 +10801,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "roughness or undue stiffness in the operation of the steering.",
+            "deficiencyTextWelsh": "garwedd neu anystwythder gormodol yng ngweithrediad y llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9823,6 +10811,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessive lift or end float of a sector shaft.",
+            "deficiencyTextWelsh": "lifft gormodol neu arnofio diwedd siafft sector.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9832,6 +10821,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessive lift or end float of a sector shaft to such an extent that functionality is affected.",
+            "deficiencyTextWelsh": "lifft gormodol neu arnofio diwedd siafft sector i'r fath raddau fel yr effeithir ar ymarferoldeb.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9841,6 +10831,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessive wear in the steering rack.",
+            "deficiencyTextWelsh": "traul gormodol yn y rac llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9850,6 +10841,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessive wear in the steering rack to such an extent that functionality is obviously affected.",
+            "deficiencyTextWelsh": "traul gormodol yn y rac llywio i'r fath raddau fel bod ymarferoldeb yn amlwg yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9859,6 +10851,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessive movement of rack housing in mounting bushes.",
+            "deficiencyTextWelsh": "symudiad gormodol o dai rac mewn llwyni mowntio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9868,6 +10861,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessive movement of rack housing in mounting bushes to such an extent that steering control is obviously affected.",
+            "deficiencyTextWelsh": "symudiad gormodol o dai rac mewn llwyni mowntio i'r fath raddau fel ei fod yn amlwg yn effeithio ar reolaeth llywio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9877,6 +10871,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a rack gaiter (if rack originally fitted with gaiters) split, damaged, missing or displaced.",
+            "deficiencyTextWelsh": "coesarn rac (os oedd rac wedi'i ffitio'n wreiddiol â choesarnau) wedi hollti, difrodi, ar goll neu wedi'i ddadleoli.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9886,6 +10881,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "a ball joint cover damaged or deteriorated but not to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "gorchudd cymal siâp pêl wedi'i ddifrodi neu wedi dirywio ond nid i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9895,6 +10891,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "a ball joint cover missing, insecure, excessively damaged or severely deteriorated to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "gorchudd cymal siâp pêl ar goll, yn ansefydlog, wedi'i ddifrodi'n ormodol neu wedi dirywio'n ddifrifol i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9904,6 +10901,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "leak of oil or grease.",
+            "deficiencyTextWelsh": "gollyngiad o olew neu saim.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9913,6 +10911,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "gear casing fractured.",
+            "deficiencyTextWelsh": "casin gêr wedi torri.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9922,6 +10921,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "gear casing fractured and obviously affects steering control or the casing is likely to become detached.",
+            "deficiencyTextWelsh": "casin gêr wedi torri ac yn amlwg yn effeithio ar reolaeth llywio neu mae'r casin yn debygol o ddatgysylltu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9931,6 +10931,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with a system component with an inappropriate modification.",
+            "deficiencyTextWelsh": "gyda chydran system ag addasiad amhriodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -9940,6 +10941,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a system component with an unsafe modification which has seriously weakened the component, does not provide sufficient clearance to other vehicle parts or renders the steering component inoperative.",
+            "deficiencyTextWelsh": "nid yw cydran system ag addasiad anniogel sydd wedi gwanhau'r gydran yn ddifrifol, yn darparu cliriad digonol i rannau eraill o'r cerbyd neu'n gwneud y gydran llywio yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -9951,6 +10953,7 @@
     "id": 50,
     "imNumber": 57,
     "imDescription": "Transmission",
+    "imDescriptionWelsh": "Trosglwyddiad",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -9994,6 +10997,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "All vehicles with:",
+        "itemDescriptionWelsh": "Pob cerbyd gyda:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10002,6 +11006,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a missing or insecure propshaft flange bolt.",
+            "deficiencyTextWelsh": "bollt fflans siafft yrru ar goll neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10011,6 +11016,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure or missing propshaft flange bolts to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "bolltau fflans siafft yrru ansefydlog neu ar goll i'r fath raddau fel bod datodiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10020,6 +11026,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "any flange cracked or insecure.",
+            "deficiencyTextWelsh": "unrhyw fflans wedi cracio neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10029,6 +11036,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "any flange cracked or insecure to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "unrhyw fflans wedi cracio neu'n ansefydlog i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10038,6 +11046,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessive wear in a shaft bearing.",
+            "deficiencyTextWelsh": "gwisgo gormodol mewn siafft dwyn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10047,6 +11056,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessive wear in a shaft bearing to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "traul gormodol mewn siafft dwyn i'r fath raddau fel bod datodiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10056,6 +11066,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a bearing housing insecure, cracked or fractured.",
+            "deficiencyTextWelsh": "beryn amgaead yn ansefydlog, wedi cracio neu wedi torri.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10065,7 +11076,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a bearing housing insecure, cracked or fractured to such an extent that detachment is likely.",
-            "stdForProhibition": false,
+            "deficiencyTextWelsh": "beryn amgaead sy'n anniogel, wedi cracio neu wedi torri i'r fath raddau fel bod datgysylltiad yn debygol.",
             "forVehicleType": ["psv", "hgv", "trl"]
           },
           {
@@ -10074,6 +11085,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "excessive wear in a universal joint.",
+            "deficiencyTextWelsh": "traul gormodol mewn cymal cyffredinol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10083,6 +11095,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessive wear in a universal joint to such an extent that detachment is likely.",
+            "deficiencyTextWelsh": "traul gormodol mewn cymal cyffredinol i'r fath raddau fel bod datgysylltiad yn debygol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10092,6 +11105,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "deterioration of a flexible coupling.",
+            "deficiencyTextWelsh": "dirywiad cyplydd hyblyg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10101,6 +11115,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "deterioration of a flexible coupling such that failure is imminent.",
+            "deficiencyTextWelsh": "dirywiad cyplydd hyblyg fel bod methiant ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10110,6 +11125,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a seriously damaged, cracked or bent shaft or a shaft which is fouling on other components.",
+            "deficiencyTextWelsh": "siafft sydd wedi'i ddifrodi'n ddifrifol, wedi cracio neu'n plygu neu siafft sy'n baeddu ar gydrannau eraill.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10119,6 +11135,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "deterioration, fracture or insecurity of a bearing housing flexible mounting.",
+            "deficiencyTextWelsh": "dirywiad, torasgwrn neu ansicrwydd cludyn sy'n cynnwys mowntin hyblyg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10128,6 +11145,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "deterioration, fracture or insecurity of a bearing housing flexible mounting such that failure is imminent.",
+            "deficiencyTextWelsh": "dirywiad, torasgwrn neu ansicrwydd cludyn sy'n cynnwys mowntin hyblyg fel bod methiant ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10136,6 +11154,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Front wheel drive shafts with:",
+        "itemDescriptionWelsh": "Siafftiau gyriant olwyn flaen gyda:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10144,6 +11163,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a constant velocity or universal joint excessively worn or insecure.",
+            "deficiencyTextWelsh": "cyflymder cyson neu gymal cyffredinol wedi treulio'n ormodol neu'n ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10153,6 +11173,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a constant velocity or universal joint excessively worn or insecure to such an extent that failure is imminent.",
+            "deficiencyTextWelsh": "cyflymder cyson neu gymal cyffredinol wedi treulio'n ormodol neu'n ansefydlog i'r fath raddau fel bod methiant ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10162,6 +11183,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a flexible coupling severely cracked, softened or breaking up.",
+            "deficiencyTextWelsh": "cyplydd hyblyg wedi cracio, meddalu neu dorri'n ddifrifol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10171,6 +11193,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a flexible coupling severely cracked, softened or breaking up such that failure is imminent.",
+            "deficiencyTextWelsh": "cyplydd hyblyg wedi cracio, meddalu neu dorri'n ddifrifol fel bod methiant ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10180,6 +11203,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "a constant velocity gaiter insecure, damaged or deteriorated but not to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "coesarn cyflymder cyson yn ansefydlog, wedi'i ddifrodi neu wedi dirywio ond nid i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10189,6 +11213,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "a constant velocity gaiter missing, insecure, excessively damaged or severely deteriorated to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "coesarn cyflymder cyson ar goll, yn ansefydlog, wedi'i niweidio'n ormodol neu wedi dirywio'n ddifrifol i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10200,6 +11225,7 @@
     "id": 51,
     "imNumber": 58,
     "imDescription": "Additional Braking Devices",
+    "imDescriptionWelsh": "Dyfeisiau Brecio Ychwanegol",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -10243,6 +11269,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Additional Braking Device:",
+        "itemDescriptionWelsh": "Dyfais Brecio Ychwanegol:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10251,6 +11278,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing when known to be a mandatory item.",
+            "deficiencyTextWelsh": "ar goll pan yn gwybod ei fod yn eitem orfodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10260,6 +11288,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "components missing, insecure, or damaged.",
+            "deficiencyTextWelsh": "cydrannau ar goll, yn ansefydlog, neu wedi'u difrodi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10269,6 +11298,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "components missing, insecure, or damaged to such an extent the device is inoperative.",
+            "deficiencyTextWelsh": "cydrannau ar goll, yn ansefydlog, neu wedi'u difrodi i'r fath raddau bod y ddyfais yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10278,6 +11308,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "wiring insecure or damaged to such an extent the device is inoperative.",
+            "deficiencyTextWelsh": "gwifrau'n ansefydlog, neu wedi'u difrodi i'r fath raddau bod y ddyfais yn anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10287,6 +11318,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with inadequate clearance with other components.",
+            "deficiencyTextWelsh": "gyda chlirio annigonol gyda chydrannau eraill",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10296,6 +11328,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "heat shield missing.",
+            "deficiencyTextWelsh": "tarian gwres ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10305,6 +11338,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "component or its surroundings overheating.",
+            "deficiencyTextWelsh": "gydran neu ei amgylchoedd yn gorboethi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10314,6 +11348,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with exhaust gas or oil leaks from the device.",
+            "deficiencyTextWelsh": "gyda nwy gwacáu neu olew yn gollwng o'r ddyfais.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10325,6 +11360,7 @@
     "id": 52,
     "imNumber": 59,
     "imDescription": "Brake Systems and Components",
+    "imDescriptionWelsh": "Systemau a Chydrannau Brêc",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -10368,6 +11404,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "Inappropriate",
+        "itemDescriptionWelsh": "Anaddas",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -10376,6 +11413,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "modification to any part of the braking system.",
+            "deficiencyTextWelsh": "addasu unrhyw ran o'r system frecio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -10385,6 +11423,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "modification to any part of the braking system and braking performance is affected.",
+            "deficiencyTextWelsh": "addasiad i unrhyw ran o'r system frecio ac effeithir ar berfformiad brecio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -10393,6 +11432,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A brake rod, clevis joint, linkage, relay, lever, pin, pivot, slack adjuster or cable:",
+        "itemDescriptionWelsh": "Rhod brêc, uniad clevis, cyswllt, relái, lifer, pin, colyn, addasydd slac neu gebl:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10401,6 +11441,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "seriously weakened by excessive wear, corrosion, damage or reduced in diameter by more than the prescribed limit.",
+            "deficiencyTextWelsh": "wedi'i wanhau'n ddifrifol gan draul gormodol, cyrydiad, difrod neu wedi'i leihau mewn diamedr gan fwy na'r terfyn rhagnodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10410,6 +11451,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with abnormal movement indicating incorrect adjustment , or excessive radial free play.",
+            "deficiencyTextWelsh": "gyda symudiad annormal yn dynodi addasiad anghywir, neu chwarae rhydd rheiddiol gormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10419,6 +11461,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with an ineffective, insecure or missing locking device.",
+            "deficiencyTextWelsh": "gyda dyfais gloi aneffeithiol, ansefydlog neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10428,6 +11471,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a brake cable knotted, or with more wires broken than permitted by the specified standard.",
+            "deficiencyTextWelsh": "cebl brêc wedi'i glymu, neu gyda mwy o wifrau wedi'u torri nag a ganiateir gan y safon benodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10437,6 +11481,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a brake cable knotted, or with more wires broken than permitted by the specified standard which obviously affects the braking performance.",
+            "deficiencyTextWelsh": "cebl brêc wedi'i glymu, neu gyda mwy o wifrau wedi'u torri nag a ganiateir gan y safon benodedig sy'n amlwg yn effeithio ar y perfformiad brecio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10446,6 +11491,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "cable guide is defective.",
+            "deficiencyTextWelsh": "canllaw cebl yn ddiffygiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10455,6 +11501,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "automatic slack adjuster component incorrectly installed, missing, disconnected, insecure, distorted, fractured or inoperative.",
+            "deficiencyTextWelsh": "cydran aseswr slac awtomatig wedi'i osod yn anghywir, ar goll, wedi'i datgysylltu, yn ansefydlog, wedi'i ystumio, wedi torri neu'n anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10464,6 +11511,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "mandatory automatic slack adjuster not fitted.",
+            "deficiencyTextWelsh": "addasydd slac awtomatig gorfodol heb ei osod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10473,6 +11521,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a brake fitted with an automatic slack adjuster exceeding two- thirds of the travel of the brake actuator, or obviously having a different travel from another brake on the same axle, or not returning fully when brakes are released.",
+            "deficiencyTextWelsh": "brêc wedi'i ffitio ag addasydd slac awtomatig sy'n fwy na dwy ran o dair o deithio'r ysgogi brêc, neu'n amlwg yn teithio'n wahanol i frêc arall ar yr un echel, neu ddim yn dychwelyd yn llawn pan ryddheir y breciau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10481,6 +11530,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Brake pipes and flexible hoses:",
+        "itemDescriptionWelsh": "Pibellau brêc a phibellau hyblyg:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10489,6 +11539,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "misplaced and fouled or chafed by moving parts, with no obvious damage evident.",
+            "deficiencyTextWelsh": "wedi'i gamleoli a'i faeddu neu'n rhuthro gan rannau symudol, heb unrhyw ddifrod amlwg i'w weld.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10498,6 +11549,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "misplaced and fouled or chafed by moving parts with obvious signs of damage.",
+            "deficiencyTextWelsh": "wedi'u camleoli a'u baeddu neu eu rhuthro gan rannau symudol gydag arwyddion amlwg o ddifrod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10507,6 +11559,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "chafed, cracked with no reinforcement cords exposed, corroded, stretched or twisted.",
+            "deficiencyTextWelsh": "wedi'i siapio, wedi cracio heb unrhyw gortynnau atgyfnerthu wedi'u hamlygu, wedi cyrydu, wedi'u hymestyn neu wedi'u troelli.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10516,6 +11569,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "excessively chafed, cracked with reinforcement cords exposed, excessively corroded, deteriorated, leaking, bulging, kinked, stretched or twisted and damage evident.",
+            "deficiencyTextWelsh": "wedi'u ruthro'n ormodol, wedi cracio â chortynnau atgyfnerthu wedi'u hamlygu, wedi cyrydu'n ormodol, wedi dirywio, yn gollwng, yn chwyddo, wedi'u tincian, wedi'u hymestyn neu'n troi a difrod yn amlwg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10525,6 +11579,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "excessively chafed, cracked with reinforcement cords exposed and damaged, excessively corroded, deteriorated, leaking, bulging, kinked, stretched or twisted and in such a condition that risk of failure is imminent.",
+            "deficiencyTextWelsh": "wedi'u ruthro'n ormodol, wedi cracio â chortynnau atgyfnerthu wedi'u hamlygu a'u difrodi, wedi cyrydu'n ormodol, wedi dirywio, yn gollwng, yn chwyddo, wedi'u tincian, wedi'u hymestyn neu'n troi ac mewn cyflwr sy'n golygu bod risg o fethiant ar fin digwydd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10534,6 +11589,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "inadequately clipped or otherwise inadequately supported.",
+            "deficiencyTextWelsh": "wedi'i glipio'n annigonol neu fel arall heb ei gefnogi'n ddigonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10543,6 +11599,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "inadequately repaired or with unsuitable joint fittings.",
+            "deficiencyTextWelsh": "heb eu hatgyweirio'n ddigonol neu gyda ffitiadau anaddas ar y cyd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10552,6 +11609,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "non-metallic pipe(s) exposed to excessive heat.",
+            "deficiencyTextWelsh": "pibell(au) anfetelaidd sy'n agored i wres gormodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10561,6 +11619,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "leaking air from a pipe or connection.",
+            "deficiencyTextWelsh": "aer yn gollwng o bibell neu gysylltiad.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10570,6 +11629,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking hydraulic fluid from a pipe or connection.",
+            "deficiencyTextWelsh": "hylif hydrolig yn gollwng o bibell neu gysylltiad.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10578,6 +11638,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "Brake drums, back plates & shoes, discs, callipers & pads including friction material with:",
+        "itemDescriptionWelsh": "Drymiau brêc, platiau cefn ac esgidiau, disgiau, calipers a phadiau gan gynnwys deunydd ffrithiant gyda:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10586,6 +11647,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a brake disc or drum excessively worn, or a brake disc cracked.",
+            "deficiencyTextWelsh": "disg brêc neu ddrwm wedi treulio'n ormodol, neu ddisg brêc wedi cracio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10595,6 +11657,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a brake back plate, disc or drum in such a condition that it is seriously weakened, fractured or insecure.",
+            "deficiencyTextWelsh": "plât cefn brêc, disg neu drwm yn y fath gyflwr fel ei fod wedi'i wanhau'n ddifrifol, wedi torri neu'n ansefydlog.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10604,6 +11667,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a brake back plate or calliper securing bolt loose or missing.",
+            "deficiencyTextWelsh": "plât cefn brêc neu galiper yn dal bollt yn rhydd neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10613,6 +11677,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a brake back plate or calliper securing bolt loose or missing to such an extent the back plate or calliper is insecure.",
+            "deficiencyTextWelsh": "plât cefn brêc neu galiper yn dal bollt yn rhydd neu ar goll i'r fath raddau mae'r plât cefn neu'r caliper yn ansefydlog.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10622,6 +11687,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a brake, lining or pad less than 1.5mm thick at any point.",
+            "deficiencyTextWelsh": "brêc, leinin neu bad llai na 1.5mm o drwch ar unrhyw adeg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10631,6 +11697,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a brake, lining or pad, missing, incorrectly fitted, insecure or with the lining/pad no longer visible.",
+            "deficiencyTextWelsh": "brêc, leinin neu bad, ar goll, wedi'i osod yn anghywir, yn anniogel neu nad yw'r leinin/pad yn weladwy rhagor.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10640,6 +11707,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "restricted movement of a brake component.",
+            "deficiencyTextWelsh": "symudiad cyfyngedig cydran brêc.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10649,6 +11717,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a brake drum, disc, lining or pad contaminated by oil or grease.",
+            "deficiencyTextWelsh": "drwm brêc, disg, leinin neu bad wedi'i halogi gan olew neu saim.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10658,6 +11727,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a brake drum, disc, lining or pad contaminated by oil or grease with the brake performance obviously affected.",
+            "deficiencyTextWelsh": "drwm brêc, disg, leinin neu bad wedi'i halogi gan olew neu saim gyda pherfformiad y brêc yn amlwg yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10666,6 +11736,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "Trailer Secondary Brake:",
+        "itemDescriptionWelsh": "Brêc Eilaidd Trelar:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -10674,6 +11745,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "defective in operation.",
+            "deficiencyTextWelsh": "diffygiol ar waith.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -10682,6 +11754,7 @@
       {
         "itemNumber": 9,
         "itemDescription": "Inappropriate:",
+        "itemDescriptionWelsh": "Anaddas",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -10690,6 +11763,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "modification to any part of the braking system.",
+            "deficiencyTextWelsh": "addasu unrhyw ran o'r system frecio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -10698,6 +11772,7 @@
       {
         "itemNumber": 9,
         "itemDescription": "Unsafe:",
+        "itemDescriptionWelsh": "Anniogel",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -10706,6 +11781,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "unsafe modification to any part of the braking system and braking performance is affected.",
+            "deficiencyTextWelsh": "addasiad anniogel i unrhyw ran o'r system frecio ac effeithir ar berfformiad brecio.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -10714,6 +11790,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Reservoir:",
+        "itemDescriptionWelsh": "Cronfa ddŵr:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10722,6 +11799,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "lightly corroded",
+            "deficiencyTextWelsh": "wedi cyrydu'n ysgafn",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10731,6 +11809,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure, excessively corroded, or leaking.",
+            "deficiencyTextWelsh": "ansefydlog, wedi cyrydu'n ormodol, neu'n gollwng.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10740,6 +11819,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "with damage or dents that do not significantly reduce the capacity.",
+            "deficiencyTextWelsh": "gyda difrod neu dolciau nad ydynt yn lleihau'r cynhwysedd yn sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10749,6 +11829,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "with damage or dents that obviously significantly reduce the capacity.",
+            "deficiencyTextWelsh": "gyda difrod neu dolciau sy'n amlwg yn lleihau'r cynhwysedd yn sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10758,6 +11839,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a securing strap fractured, cracked, excessively corroded or chafing on the reservoir or other mounting.",
+            "deficiencyTextWelsh": "gyda strap diogelu wedi'i dorri, wedi cracio, wedi rhydu'n ormodol neu'n rhuthro ar y gronfa ddŵr neu fowntiad arall.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10767,6 +11849,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing where it is known to be a standard fitting.",
+            "deficiencyTextWelsh": "ar goll lle gwyddys ei fod yn ffitiad safonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10775,6 +11858,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "Actuators, hydraulic master & wheel cylinders, valves and servos:",
+        "itemDescriptionWelsh": "Ysgogiadau aer, meistr hydrolig a silindrau olwyn, falfiau a serfos:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10783,6 +11867,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "defective in operation.",
+            "deficiencyTextWelsh": "diffygiol ar waith.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10792,6 +11877,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "defective in operation and brake performance affected.",
+            "deficiencyTextWelsh": "diffygiol o ran gweithrediad ac effeithir ar berfformiad brêc.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10801,6 +11887,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure but still operational.",
+            "deficiencyTextWelsh": "ansefydlog ond yn dal yn weithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10810,6 +11897,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "insecure and brake performance affected.",
+            "deficiencyTextWelsh": "anniogel a pherfformiad brêc yr effeithir arnynt.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10819,6 +11907,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "leaking air or fluid, fractured, cracked, excessively damaged or corroded.",
+            "deficiencyTextWelsh": "aer neu hylif yn gollwng, wedi torri, wedi cracio, wedi'i ddifrodi'n ormodol neu wedi cyrydu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10828,6 +11917,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "leaking air or fluid, fractured, cracked, excessively damaged or corroded and brake performance is affected.",
+            "deficiencyTextWelsh": "aer neu hylif yn gollwng, wedi torri, wedi cracio, wedi'i ddifrodi'n ormodol neu wedi cyrydu ac mae perfformiad brêc yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10837,6 +11927,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a locking device missing or insecure.",
+            "deficiencyTextWelsh": "gyda dyfais gloi ar goll neu'n ansicr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10846,6 +11937,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "with insufficient or excessive travel of operating mechanism indicating a need for adjustment.",
+            "deficiencyTextWelsh": "gyda theithio annigonol neu ormodol o fecanwaith gweithredu sy'n dangos bod angen addasu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10855,6 +11947,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "with insufficient or excessive travel of operating mechanism indicating a need for adjustment and brake performance is affected.",
+            "deficiencyTextWelsh": "gyda theithio annigonol neu ormodol o fecanwaith gweithredu sy'n dangos bod angen addasu a pherfformiad brêc yn cael ei effeithio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10864,6 +11957,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a cap missing from a hydraulic master cylinder and/or fluid obviously contaminated.",
+            "deficiencyTextWelsh": "gyda chap ar goll o brif silindr hydrolig a/neu hylif yn amlwg wedi'i halogi.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10873,6 +11967,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "fluid below minimum level or level warning device defective/activated.",
+            "deficiencyTextWelsh": "hylif o dan y lefel isaf neu ddyfais rhybudd lefel yn ddiffygiol/actifedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10882,6 +11977,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "fluid significantly below minimum level.",
+            "deficiencyTextWelsh": "hylif yn sylweddol is na'r lefel isafswm.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10891,6 +11987,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "no visible fluid.",
+            "deficiencyTextWelsh": "dim hylif gweladwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10900,6 +11997,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "with a valve with excessive discharge of oil.",
+            "deficiencyTextWelsh": "gyda falf â gollyngiad gormodol o olew.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10909,6 +12007,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a load sensing valve removed or disconnected when it is known to be a standard fitment.",
+            "deficiencyTextWelsh": "falf synhwyro llwyth yn cael ei thynnu neu ei ddatgysylltu pan yn gwybod ei fod yn ffitiad safonol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10918,6 +12017,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "a load sensing valve obviously seized or restricted in its free movement, linkage or brackets cracked, defective or out of adjustment (ABS functioning).",
+            "deficiencyTextWelsh": "falf synhwyro llwyth yn amlwg wedi'i atafaelu neu ei gyfyngu o ran ei symudiad rhydd, cysylltiad neu fracedi wedi cracio, yn ddiffygiol neu allan o addasiad (swyddogaeth ABS).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10927,6 +12027,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "a load sensing valve obviously seized or restricted in its free movement, linkage or brackets cracked, defective or out of adjustment. (No ABS function).",
+            "deficiencyTextWelsh": "falf synhwyro llwyth yn amlwg wedi'i atafaelu neu ei gyfyngu o ran ei symudiad rhydd, cysylltiad neu fracedi wedi cracio, yn ddiffygiol neu allan o addasiad. (Dim swyddogaeth ABS).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10936,6 +12037,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "hydraulic brake actuator dust cover damaged or deteriorated but not to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "gorchudd llwch ysgogi brêc hydrolig wedi'i ddifrodi neu wedi dirywio ond nid i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10945,6 +12047,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "hydraulic brake actuator dust cover missing, insecure, excessively damaged or severely deteriorated to the extent that it would no longer prevent the ingress of dirt etc.",
+            "deficiencyTextWelsh": "gorchudd llwch ysgogi brêc hydrolig ar goll, yn ansefydlog, wedi'i ddifrodi'n ormodol neu wedi dirywio'n ddifrifol i'r graddau na fyddai bellach yn atal baw rhag mynd i mewn ac ati.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10953,6 +12056,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "A load sensing data plate is:",
+        "itemDescriptionWelsh": "Plât data synhwyro llwyth:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10961,6 +12065,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "missing or illegible.",
+            "deficiencyTextWelsh": "ar goll neu'n annarllenadwy.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10969,6 +12074,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "Air Compressor Drive:",
+        "itemDescriptionWelsh": "Gyriant Cywasgydd Aer:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -10977,6 +12083,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a drive belt missing, badly deteriorated and/ or so loose that it is likely to slip.",
+            "deficiencyTextWelsh": "gwregys gyrru ar goll, wedi dirywio'n ddrwg a/neu gymaint yn rhydd fel ei fod yn debygol o lithro.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -10986,6 +12093,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a compressor drive pulley loose, cracked or missing.",
+            "deficiencyTextWelsh": "pwli gyriant cywasgwr yn rhydd, wedi cracio neu ar goll.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -10997,6 +12105,7 @@
     "id": 53,
     "imNumber": 62,
     "imDescription": "Markers and Reflectors",
+    "imDescriptionWelsh": "Marcwyr ac Adlewyrchwyr",
     "forVehicleType": ["hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -11040,6 +12149,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Reflectors, conspicuity markings and/or rear markers:",
+        "itemDescriptionWelsh": "Adlewyrchwyr, marciau amlygrwydd a/neu farcwyr cefn:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -11048,6 +12158,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "incorrectly positioned.",
+            "deficiencyTextWelsh": "wedi'i leoli'n anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11057,6 +12168,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "missing, incorrectly positioned and red colour is reflected to the front or white to the rear.",
+            "deficiencyTextWelsh": "ar goll, wedi'i leoli'n anghywir a lliw coch yn cael ei adlewyrchu ar y blaen neu wyn yn y cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11066,6 +12178,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11075,6 +12188,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure and likely to become detached.",
+            "deficiencyTextWelsh": "ansefydlog ac yn debygol o ddatgysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11084,6 +12198,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "not clearly visible.",
+            "deficiencyTextWelsh": "ddim i'w weld yn glir.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11093,6 +12208,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "of the incorrect type fitted.",
+            "deficiencyTextWelsh": "o'r math anghywir wedi'i osod.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11102,6 +12218,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "dirty or ineffective.",
+            "deficiencyTextWelsh": "budr neu aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11111,6 +12228,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "so dirty or ineffective that its function is obviously impaired.",
+            "deficiencyTextWelsh": "mor fudr neu aneffeithiol fel bod ei swyddogaeth yn amlwg yn cael ei amharu.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11120,6 +12238,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "broken, damaged or incomplete.",
+            "deficiencyTextWelsh": "wedi torri neu'n anghyflawn",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11129,6 +12248,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "broken, damaged or incomplete to the extent that the reflecting area is significantly reduced.",
+            "deficiencyTextWelsh": "wedi torri, wedi'i ddifrodi neu'n anghyflawn i'r graddau bod yr ardal adlewyrchol yn cael ei leihau'n sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11138,6 +12258,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "not of the appropriate colour.",
+            "deficiencyTextWelsh": "ddim o'r lliw priodol.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           },
@@ -11147,6 +12268,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "not of the appropriate colour with red colour reflected to the front or white colour to the rear.",
+            "deficiencyTextWelsh": "ddim o'r lliw priodol gyda lliw coch wedi'i adlewyrchu i'r blaen neu liw gwyn yn y cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -11158,6 +12280,7 @@
     "id": 54,
     "imNumber": 62,
     "imDescription": "Reflectors and Rear Markings",
+    "imDescriptionWelsh": "Adlewyrchyddion a Marciau Cefn",
     "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
@@ -11201,6 +12324,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Reflectors and/or rear markings:",
+        "itemDescriptionWelsh": "Adlewyrchyddion a/neu marciau cefn:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -11209,6 +12333,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "incorrectly positioned.",
+            "deficiencyTextWelsh": "wedi'i leoli'n anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11218,6 +12343,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "missing, incorrectly positioned and red colour is reflected to the front or white to the rear.",
+            "deficiencyTextWelsh": "ar goll, wedi'i leoli'n anghywir a lliw coch yn cael ei adlewyrchu ar y blaen neu wyn yn y cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11227,6 +12353,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "insecure.",
+            "deficiencyTextWelsh": "yn anniogel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11236,6 +12363,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "insecure and likely to become detached.",
+            "deficiencyTextWelsh": "ansefydlog ac yn debygol o ddatgysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11245,6 +12373,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "not clearly visible.",
+            "deficiencyTextWelsh": "ddim i'w weld yn glir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11254,6 +12383,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "of the incorrect type fitted.",
+            "deficiencyTextWelsh": "o'r math anghywir wedi'i osod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11263,6 +12393,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "dirty or ineffective.",
+            "deficiencyTextWelsh": "budr neu aneffeithiol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11272,6 +12403,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "so dirty or ineffective that its function is obviously impaired.",
+            "deficiencyTextWelsh": "mor fudr neu aneffeithiol fel bod ei swyddogaeth yn amlwg yn cael ei amharu.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11281,6 +12413,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "broken, damaged or incomplete.",
+            "deficiencyTextWelsh": "wedi torri neu'n anghyflawn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11290,6 +12423,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "broken, damaged or incomplete to the extent that the reflecting area is significantly reduced.",
+            "deficiencyTextWelsh": "wedi torri, wedi'i ddifrodi neu'n anghyflawn i'r graddau bod yr ardal adlewyrchol yn cael ei leihau'n sylweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11299,6 +12433,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "not of the appropriate colour.",
+            "deficiencyTextWelsh": "ddim o'r lliw priodol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           },
@@ -11308,6 +12443,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "not of the appropriate colour with red colour reflected to the front or white colour to the rear.",
+            "deficiencyTextWelsh": "ddim o'r lliw priodol gyda lliw coch wedi'i adlewyrchu i'r blaen neu liw gwyn yn y cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv"]
           }
@@ -11319,6 +12455,7 @@
     "id": 55,
     "imNumber": 63,
     "imDescription": "Lamps",
+    "imDescriptionWelsh": "Lampau",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -11362,6 +12499,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "Reversing lamp (in addition to 1 above):",
+        "itemDescriptionWelsh": "Lamp bacio (yn ogystal ag 1 uchod):",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11370,6 +12508,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "more than two (motor vehicles up to 6m in length) or four (motor vehicles over 6m in length) optional reversing lamps fitted.",
+            "deficiencyTextWelsh": "mwy na dau (cerbydau modur hyd at 6m o hyd) neu bedwar (cerbydau modur dros 6m o hyd) lampau bacio dewisol wedi'u gosod.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11379,6 +12518,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not operate automatically when reverse gear is selected.",
+            "deficiencyTextWelsh": "nid yw'n gweithredu'n awtomatig pan ddewisir gêr gwrthdro.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11387,6 +12527,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "For all lamps:",
+        "itemDescriptionWelsh": "Ar gyfer pob lamp:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -11395,6 +12536,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "any lamp insecure but unlikely to become detached",
+            "deficiencyTextWelsh": "unrhyw lamp yn anniogel ond yn annhebygol o ddatgysylltiedig",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11404,6 +12546,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "any lamp insecure and likely to become detached.",
+            "deficiencyTextWelsh": "unrhyw lamp yn anniogel ac yn debygol o ddatgysylltiedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11413,6 +12556,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an obligatory lamp missing or inoperative",
+            "deficiencyTextWelsh": "lamp orfodol ar goll neu'n anweithredol",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11422,6 +12566,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "an obligatory lamp dim due to dirt or internal deterioration or with a partially reduced light output.",
+            "deficiencyTextWelsh": "lamp gorfodol yn pylu oherwydd baw neu ddirywiad mewnol neu gydag allbwn golau wedi'i leihau'n rhannol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11431,6 +12576,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "an obligatory lamp dim due to dirt or internal deterioration or with an obvious major reduction in light output.",
+            "deficiencyTextWelsh": "lamp gorfodol yn pylu oherwydd baw neu ddirywiad mewnol neu gyda gostyngiad mawr amlwg mewn allbwn golau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11440,6 +12586,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "an obligatory lamp lens obscured partially, insecure, or damaged but not likely to fall apart.",
+            "deficiencyTextWelsh": "lens lamp orfodol wedi'i chuddio'n rhannol, yn ansefydlog, neu wedi'i ddifrodi ond ddim yn debygol o ddisgyn yn ddarnau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11449,6 +12596,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "a obligatory lamp lens missing, obscured, insecure and or damaged so it is likely to fall apart.",
+            "deficiencyTextWelsh": "lens lamp orfodol ar goll, wedi'i chuddio, yn ansefydlog a/neu wedi'i difrodi fel ei fod yn debygol o ddisgyn yn ddarnau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11458,6 +12606,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "an obligatory lamp not showing a light of the right colour.",
+            "deficiencyTextWelsh": "lamp orfodol nad yw'n dangos golau o'r lliw cywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11467,6 +12616,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "an obligatory lamp not showing a light of the right colour with red light shown to the front or white light shown to the rear.",
+            "deficiencyTextWelsh": "lamp gorfodi nad yw'n dangos golau o'r lliw cywir gyda golau coch wedi'i ddangos ar y blaen neu olau gwyn yn y cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11476,6 +12626,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an obligatory lamp incorrectly positioned.",
+            "deficiencyTextWelsh": "lamp orfodol wedi'i leoli'n anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11485,6 +12636,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "an obligatory lamp is affected by the operation of any other lamp.",
+            "deficiencyTextWelsh": "lamp gorfodol yn cael ei effeithio gan weithrediad unrhyw lamp arall.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -11493,6 +12645,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Rear Fog lamp:(in addition to 1 above)",
+        "itemDescriptionWelsh": "Lamp niwl cefn: (yn ogystal ag 1 uchod)",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -11501,6 +12654,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tell-tale light not fitted, not working or cannot be seen by the driver.",
+            "deficiencyTextWelsh": "golau heb ei ffitio, ddim yn gweithio neu ddim yn gallu cael ei weld gan y gyrrwr.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11510,6 +12664,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "more than two rear fog lamps are fitted.",
+            "deficiencyTextWelsh": "gosodir mwy na dwy lamp niwl cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11519,6 +12674,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "non obligatory rear fog lamp(s) affected by the operation of the foot brake and or shows the incorrect colour.",
+            "deficiencyTextWelsh": "lamp(iau) niwl cefn nad yw'n orfodol yr effeithir arnynt gan weithrediad y brêc troed a/neu sy'n dangos y lliw anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -11552,6 +12708,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "Headlamp: (in addition to 1 above)",
+        "itemDescriptionWelsh": "Lamp fawr: (yn ogystal ag 1 uchod)",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11560,6 +12717,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not forming part of a matched pair.",
+            "deficiencyTextWelsh": "ddim yn ffurfio rhan o bâr cyfatebol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11569,6 +12727,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not positioned symmetrically in relation to the other lamp.",
+            "deficiencyTextWelsh": "heb ei leoli'n gymesur mewn perthynas â'r lamp arall.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11578,6 +12737,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "one of a matched pair does not show a light of the same intensity and colour as the other.",
+            "deficiencyTextWelsh": "nid yw un o bâr cyfatebol yn dangos golau o'r un dwyster a lliw â'r llall.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11587,6 +12747,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a main beam headlamp cannot be switched off by operating one switch which at the same time leaves a pair of dipped beams.",
+            "deficiencyTextWelsh": "ni ellir diffodd pelydr prif lamp trwy weithredu un switsh sydd ar yr un pryd yn gadael pâr o belydrau wedi'u dipio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11596,6 +12757,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "main beam warning lamp does not illuminate when main beam is selected and extinguish when dipped beam is selected.",
+            "deficiencyTextWelsh": "nid yw pelydr rhybudd prif lamp yn goleuo pan fydd y prif drawst yn cael ei ddewis ac yn diffodd pan ddewisir pelydr wedi dipio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11605,6 +12767,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "cleaning device inoperative.",
+            "deficiencyTextWelsh": "dyfais glanhau anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11614,6 +12777,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "cleaning device inoperative for LED or  gas discharge (HID) systems.",
+            "deficiencyTextWelsh": "dyfais glanhau anweithredol ar gyfer systemau LED neu ollwng nwy (HID).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11622,6 +12786,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "A rear registration plate lamp (in addition to 1 above)",
+        "itemDescriptionWelsh": "Lamp plât cofrestru cefn (yn ogystal ag 1 uchod)",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -11630,6 +12795,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "throws direct light to the rear.",
+            "deficiencyTextWelsh": "yn taflu golau uniongyrchol i'r cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -11638,6 +12804,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "Front fog lamp (in addition to 1 above)",
+        "itemDescriptionWelsh": "Lamp niwl blaen (yn ogystal ag 1 uchod)",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11646,6 +12813,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "inoperative.",
+            "deficiencyTextWelsh": "anweithredol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11654,6 +12822,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "Day time running lamp (in addition to 1 above):",
+        "itemDescriptionWelsh": "Lamp rhedeg yn ystod y dydd (yn ogystal ag 1 uchod):",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11662,6 +12831,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "minor",
             "deficiencyText": "not showing a light of the right colour.",
+            "deficiencyTextWelsh": "ddim dangos golau o'r lliw cywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11671,6 +12841,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "not showing a light of the right colour with red light shown to the front or white light shown to the rear.",
+            "deficiencyTextWelsh": "ddim yn dangos golau o'r lliw cywir gyda golau coch wedi'i ddangos ar y blaen neu olau gwyn yn y cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11680,6 +12851,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "incorrectly positioned.",
+            "deficiencyTextWelsh": "wedi'i leoli'n anghywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11691,6 +12863,7 @@
     "id": 56,
     "imNumber": 66,
     "imDescription": "Direction Indicators and Hazard Warning Lamps",
+    "imDescriptionWelsh": "Cyfeirwyr a Lampau Rhybudd Perygl",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -11734,6 +12907,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Direction indicator:",
+        "itemDescriptionWelsh": "Dangosydd cyfeiriad:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -11742,6 +12916,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "missing, inoperative, operating on the wrong side of a vehicle/trailer, not visible either to the front, side, or to the rear.",
+            "deficiencyTextWelsh": "ar goll, yn anweithredol, yn gweithredu ar ochr anghywir cerbyd/trelar, ddim yn weladwy naill ai i'r blaen, i'r ochr nac i'r cefn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11751,6 +12926,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "a lamp dim due to dirt or internal deterioration or with partially reduced light output.",
+            "deficiencyTextWelsh": "lamp yn pylu oherwydd baw neu ddirywiad mewnol neu gydag allbwn golau wedi'i leihau'n rhannol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11760,6 +12936,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "a lamp dim due to dirt or internal deterioration or with an obvious major reduction in light output.",
+            "deficiencyTextWelsh": "lamp yn pylu oherwydd baw neu ddirywiad mewnol neu gyda gostyngiad mawr amlwg mewn allbwn golau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11769,6 +12946,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "minor",
             "deficiencyText": "lens insecure or damaged with no effect on light output.",
+            "deficiencyTextWelsh": "lens yn ansefydlog neu wedi'i ddifrodi heb unrhyw effaith ar allbwn golau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11778,6 +12956,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "major",
             "deficiencyText": "lens missing, insecure or damaged so that it is likely to fall apart to such an extent that light output is obviously affected.",
+            "deficiencyTextWelsh": "lens ar goll, yn ansefydlog neu wedi'i ddifrodi fel ei fod yn debygol o ddisgyn i'r fath raddau fel ei fod yn amlwg yn effeithio ar allbwn golau.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11787,6 +12966,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not flash at between 60 to 120 times a minute.",
+            "deficiencyTextWelsh": "ddim yn fflachio rhwng 60 a 120 gwaith y funud.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11796,6 +12976,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not show a light of the right colour.",
+            "deficiencyTextWelsh": "ddim yn dangos golau o'r lliw cywir.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -11805,6 +12986,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tell-tale not fitted, is inoperative or cannot be seen/heard by the driver.",
+            "deficiencyTextWelsh": "heb ei ffitio, yn anweithredol neu ni all y gyrrwr ei weld/clywed.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -11813,6 +12995,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Hazard warning lamp:",
+        "itemDescriptionWelsh": "Lamp rhybudd perygl:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11821,6 +13004,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "does not operate with the engine stopped and the ignition switched off and on.",
+            "deficiencyTextWelsh": "ddim yn gweithredu gyda'r injan wedi'i stopio a'r taniad wedi'i ddiffodd ac ymlaen.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11830,6 +13014,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "all the direction indicator lamps do not operate simultaneously when switched on by one switch.",
+            "deficiencyTextWelsh": "nid yw'r holl lampau dangosydd cyfeiriad yn gweithredu ar yr un pryd pan cânt eu troi ymlaen gan un switsh.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11839,6 +13024,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "tell-tale not fitted, is inoperative or cannot be seen by the driver.",
+            "deficiencyTextWelsh": "heb ei ffitio, yn anweithredol neu ni all y gyrrwr ei weld.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11850,6 +13036,7 @@
     "id": 57,
     "imNumber": 67,
     "imDescription": "Aim of Headlamps",
+    "imDescriptionWelsh": "Nod y Lampau Fawr",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -11882,6 +13069,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "European checked on Dipped Beam: In relation to the 0% Horizontal line, the beam horizontal cut-off line is not between the limits listed below.",
+        "itemDescriptionWelsh": "Wedi'i wirio gan Ewrop ar Belydr Trochog: Mewn perthynas â'r llinell lorweddol 0%, nid yw llinell doriad llorweddol y belydr rhwng y terfynau a restrir isod.",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11890,6 +13078,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Headlamp centres up to and including 850mm high Upper limit: All vehicles. 0.5%  Lower limit: All vehicles  4.0%",
+            "deficiencyTextWelsh": "Canolbwynt y lampau fawr hyd at ac yn cynnwys 850mm o uchder Terfyn uchaf: Pob cerbyd. 0.5% Terfyn isaf: Pob cerbyd 4.0%",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -11899,6 +13088,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Headlamp centres over 850mm high Upper limit: All vehicles. 1.25%  Lower limit: All vehicles 4.0%",
+            "deficiencyTextWelsh": "Canolbwynt y lampau fawr dros 850mm o uchder Terfyn uchaf: Pob cerbyd. 1.25% Terfyn isaf: Pob cerbyd 4.0%",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11907,6 +13097,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "European checked on Dipped Beam: The beam image contains:",
+        "itemDescriptionWelsh": "Gwiriad Ewropeaidd ar Belydr Trochog: Mae delwedd y pelydr yn cynnwys:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11915,6 +13106,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "a “Kick up” that is not visible on the screen",
+            "deficiencyTextWelsh": "Kick up“ nad yw'n weladwy ar y sgrin",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11923,6 +13115,7 @@
       {
         "itemNumber": 3,
         "itemDescription": "European checked on Dipped Beam: White light:",
+        "itemDescriptionWelsh": "Gwiriad Ewropeaidd ar Belydr Trochog: Golau gwyn:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11931,6 +13124,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "shows in the zone formed by the 0% vertical and 0.5% horizontal lines.",
+            "deficiencyTextWelsh": "yn dangos yn y parth a ffurfiwyd gan y llinellau fertigol 0% a 0.5% llorweddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11939,6 +13133,7 @@
       {
         "itemNumber": 4,
         "itemDescription": "British American Checked on Dipped Beam: In relation to the 0% Horizontal line, the upper edge of the “Hot Spot” is not between the limits listed below.",
+        "itemDescriptionWelsh": "Americanaidd Prydeinig wedi'i Wirio ar Belydr Trochog: Mewn perthynas â'r llinell lorweddol 0%, nid yw ymyl uchaf y “Man Poeth” rhwng y terfynau a restrir isod.",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11947,6 +13142,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "All headlamp heights, Upper limit: All vehicles. 0%, Lower limit: All vehicles 4.0%",
+            "deficiencyTextWelsh": "Pob uchder lampau pen, Terfyn uchaf: Pob cerbyd. 0%, terfyn isaf: Pob cerbyd 4.0%",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11955,6 +13151,7 @@
       {
         "itemNumber": 5,
         "itemDescription": "British American Checked on Dipped Beam: The right hand edge of the “Hot Spot”:",
+        "itemDescriptionWelsh": "Americanaidd Prydeinig wedi'i Wirio ar Belydr Trochog: Ymyl dde'r “Man Poeth”:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11963,6 +13160,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is to the right of the vertical 0% line, or more than 2% to the left of it.",
+            "deficiencyTextWelsh": "i'r dde o'r llinell fertigol 0% neu fwy na 2% i'r chwith ohoni.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11971,6 +13169,7 @@
       {
         "itemNumber": 6,
         "itemDescription": "British American Checked on Dipped Beam: A Headlamp",
+        "itemDescriptionWelsh": "Americanaidd Prydeinig wedi'i Wirio ar Belydr Trochog: Lamp Fawr",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11979,6 +13178,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "dips to the right (See note in Applications).",
+            "deficiencyTextWelsh": "yn dipio i'r dde (Gweler y nodyn yn Ceisiadau).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -11987,6 +13187,7 @@
       {
         "itemNumber": 7,
         "itemDescription": "British American Checked on Main Beam: In relation to the 0% Horizontal line, the Centre of the “Hot Spot” is not between the limits listed below.",
+        "itemDescriptionWelsh": "Americanaidd Prydeinig wedi'i Wirio ar y Prif Belydr: Mewn perthynas â'r llinell lorweddol 0%, nid yw Canolfan y “Man Poeth” rhwng y terfynau a restrir isod.",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -11995,6 +13196,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Headlamp centres up to and including 850mm high, Upper limit: All vehicles. 0%, Lower limit: All vehicles. 2.0%.",
+            "deficiencyTextWelsh": "Canolbwynt y lampau fawr hyd at ac yn cynnwys 850mm o uchder Terfyn uchaf: Pob cerbyd. 0%, Terfyn isaf: Pob cerbyd 2.0%.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12004,6 +13206,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Headlamp centres over 850mm high, Upper limit: All vehicles. 0%, Lower limit: All vehicles. 2.75%.",
+            "deficiencyTextWelsh": "Canolbwynt y lampau fawr dros 850mm o uchder Terfyn uchaf: Pob cerbyd. 0% Terfyn isaf: Pob cerbyd 2.75%.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12012,6 +13215,7 @@
       {
         "itemNumber": 8,
         "itemDescription": "British American Checked on Main Beam: In any case the centre of the “Hot Spot”",
+        "itemDescriptionWelsh": "Americanwr Prydeinig wedi'i Wirio ar y Prif Belydr: ym mhob achos canol y “Man Poeth”",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -12020,6 +13224,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "is to the right of the vertical 0% line or more than 2% to the left of it.",
+            "deficiencyTextWelsh": "i'r dde o'r llinell fertigol 0% neu fwy na 2% i'r chwith ohoni.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12028,6 +13233,7 @@
       {
         "itemNumber": 9,
         "itemDescription": "British American Checked on Main Beam: A Headlamp",
+        "itemDescriptionWelsh": "Americanaidd Prydeinig wedi'i Wirio ar y Prif Belydr: Lamp Fawr",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -12036,6 +13242,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "dips to the right (see note in Application).",
+            "deficiencyTextWelsh": "yn dipio i'r dde (gweler y nodyn yn Cais).",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12047,6 +13254,7 @@
     "id": 58,
     "imNumber": 71,
     "imDescription": "Service Brake Performance",
+    "imDescriptionWelsh": "Perfformiad Brêc Gwasanaeth",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -12090,6 +13298,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "All Roller Brake Test Machines:",
+        "itemDescriptionWelsh": "Pob Peiriant Prawf Brêc Rholio:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -12098,6 +13307,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "A brake on any wheel binding.",
+            "deficiencyTextWelsh": "Brêc ar unrhyw rwymo olwyn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12107,6 +13317,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "Brake mechanism on any wheel sticking, indicated by an abnormal time lag before an increased reading is obtained.",
+            "deficiencyTextWelsh": "Mecanwaith brêc ar unrhyw olwyn yn glynu, wedi'i nodi gan oedi annormal cyn cael darlleniad cynyddol.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12116,6 +13327,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "With service brake applied at a steady pedal pressure, the indication of brake effort fluctuates regularly with each brake revolution of the road wheel, on a steered axle, so much that the ovality of any brake drum is obvious. A fluctuation reading in excess of 70%, between highest and lowest indicated readings is to be considered a deficiency.",
+            "deficiencyTextWelsh": "Gyda brêc gwasanaeth yn cael ei gymhwyso ar bwysedd pedal cyson, mae'r arwydd o ymdrech brêc yn amrywio'n rheolaidd gyda phob chwyldro brêc o'r olwyn ffordd, ar echel wedi'i lywio, cymaint fel bod hirgrwn unrhyw drwm brêc yn amlwg. Mae darlleniad anwadal o fwy na 70%, rhwng y darlleniadau uchaf ac isaf a nodir i'w ystyried yn ddiffyg.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12124,6 +13336,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "All Roller Brake Test Machines: With the service brake fully applied:",
+        "itemDescriptionWelsh": "Pob Peiriant Prawf Brêc Rholio: Gyda'r brêc gwasanaeth wedi'i gymhwyso'n llawn:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -12132,6 +13345,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "there is very little brake effort at any wheel.",
+            "deficiencyTextWelsh": "ychydig iawn o ymdrech brêc sydd ar unrhyw olwyn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12141,6 +13355,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "there is no brake effort at any wheel.",
+            "deficiencyTextWelsh": "nid oes unrhyw ymdrech brêc ar unrhyw olwyn.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12150,6 +13365,7 @@
             "deficiencySubId": "iii",
             "deficiencyCategory": "major",
             "deficiencyText": "braking effort from any wheel on an axle is less than 70% of the brake effort from another wheel on the same axle.",
+            "deficiencyTextWelsh": "ymdrech brecio o unrhyw olwyn ar echel yn llai na 70% o'r ymdrech brêc o olwyn arall ar yr un echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12159,6 +13375,7 @@
             "deficiencySubId": "iv",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "braking effort from any wheel on an axle is less than 50% of the brake effort from another wheel on the same axle in the case of steered axles.",
+            "deficiencyTextWelsh": "ymdrech brecio o unrhyw olwyn ar echel yn llai na 50% o'r ymdrech brêc o olwyn arall ar yr un echel yn achos echelau wedi'u llywio.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12168,6 +13385,7 @@
             "deficiencySubId": "v",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "the specified brake effort is not met.",
+            "deficiencyTextWelsh": "ni fodlonir yr ymdrech brêc penodedig.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -12176,6 +13394,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Decelerometer test:",
+        "itemDescriptionWelsh": "Prawf deceleromedr:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -12184,6 +13403,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the braking efficiency recorded by decelerometer is below the specified efficiency.",
+            "deficiencyTextWelsh": "mae'r effeithlonrwydd brecio a gofnodwyd gan deceleromedr yn is na'r effeithlonrwydd penodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12193,6 +13413,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the vehicle deviates appreciably from a straight line.",
+            "deficiencyTextWelsh": "y cerbyd yn gwyro'n sylweddol o linell syth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12204,6 +13425,7 @@
     "id": 59,
     "imNumber": 72,
     "imDescription": "Secondary Brake Performance",
+    "imDescriptionWelsh": "Perfformiad Brêc Eilaidd",
     "forVehicleType": ["psv", "hgv"],
     "additionalInfo": {
       "psv": {
@@ -12236,6 +13458,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "All Roller Brake Test Machines, with the secondary brake fully applied:",
+        "itemDescriptionWelsh": "Pob Peiriant Prawf Brêc Rholio: gyda'r brêc eilaidd wedi'i gymhwyso'n llawn:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -12244,6 +13467,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "there is very little braking effort at any wheel equipped with a brake operated by the secondary brake system.",
+            "deficiencyTextWelsh": "ychydig iawn o ymdrech frecio sydd ar unrhyw olwyn sydd â brêc a weithredir gan y system brêc eilaidd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12253,6 +13477,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "there is no braking effort at all on any wheel equipped with a brake operated by the secondary brake system.",
+            "deficiencyTextWelsh": "nid oes unrhyw ymdrech frecio o gwbl ar unrhyw olwyn sydd â brêc a weithredir gan y system brêc eilaidd.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12262,6 +13487,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "braking effort from any wheel on an axle is less than 70% of the brake effort from another wheel on the same axle.",
+            "deficiencyTextWelsh": "ymdrech brecio o unrhyw olwyn ar echel yn llai na 70% o'r ymdrech brêc o olwyn arall ar yr un echel.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12271,6 +13497,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "braking effort from any wheel on an axle is less than 50% of the brake effort from another wheel on the same axle in the case of steered axles.",
+            "deficiencyTextWelsh": "ymdrech brecio o unrhyw olwyn ar echel yn llai na 50% o'r ymdrech brêc o olwyn arall ar yr un echel yn achos echelau wedi'u llywio.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12280,6 +13507,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "the specified brake effort is not met.",
+            "deficiencyTextWelsh": "ni fodlonir yr ymdrech brêc penodedig.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12288,6 +13516,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Decelerometer test:",
+        "itemDescriptionWelsh": "Prawf deceleromedr:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -12296,6 +13525,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the braking efficiency recorded by decelerometer is below the specified efficiency.",
+            "deficiencyTextWelsh": "mae'r effeithlonrwydd brecio a gofnodwyd gan deceleromedr yn is na'r effeithlonrwydd penodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12305,6 +13535,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the vehicle deviates appreciably from a straight line.",
+            "deficiencyTextWelsh": "y cerbyd yn gwyro'n sylweddol o linell syth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12316,6 +13547,7 @@
     "id": 60,
     "imNumber": 73,
     "imDescription": "Parking Brake Performance",
+    "imDescriptionWelsh": "Perfformiad Brac Parcio",
     "forVehicleType": ["psv", "hgv", "trl"],
     "additionalInfo": {
       "psv": {
@@ -12359,6 +13591,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Roller Brake Test: With the parking brake fully applied:",
+        "itemDescriptionWelsh": "Prawf Brêc Rholer: Gyda'r brêc parcio wedi'i gymhwyso'n llawn:",
         "forVehicleType": ["psv", "hgv", "trl"],
         "deficiencies": [
           {
@@ -12367,6 +13600,7 @@
             "deficiencySubId": "i",
             "deficiencyCategory": "major",
             "deficiencyText": "there is very little braking effort at any wheel equipped with a brake operated by the parking brake system.",
+            "deficiencyTextWelsh": "ychydig iawn o ymdrech frecio sydd ar unrhyw olwyn sydd â brêc a weithredir gan y system brêc parcio.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12376,6 +13610,7 @@
             "deficiencySubId": "ii",
             "deficiencyCategory": "dangerous",
             "deficiencyText": "there is no braking effort at all on any wheel equipped with a brake operated by the parking brake system.",
+            "deficiencyTextWelsh": "nid oes unrhyw ymdrech frecio o gwbl ar unrhyw olwyn sydd â brêc a weithredir gan y system brêc parcio.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           },
@@ -12385,6 +13620,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "the specified brake effort is not met.",
+            "deficiencyTextWelsh": "ni fodlonir yr ymdrech brêc penodedig.",
             "stdForProhibition": true,
             "forVehicleType": ["psv", "hgv", "trl"]
           }
@@ -12393,6 +13629,7 @@
       {
         "itemNumber": 2,
         "itemDescription": "Decelerometer test:",
+        "itemDescriptionWelsh": "Prawf deceleromedr:",
         "forVehicleType": ["psv", "hgv"],
         "deficiencies": [
           {
@@ -12401,6 +13638,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the braking efficiency recorded by decelerometer is below the specified efficiency.",
+            "deficiencyTextWelsh": "mae'r effeithlonrwydd brecio a gofnodwyd gan deceleromedr yn is na'r effeithlonrwydd penodedig.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           },
@@ -12410,6 +13648,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "major",
             "deficiencyText": "the vehicle deviates appreciably from a straight line.",
+            "deficiencyTextWelsh": "y cerbyd yn gwyro'n sylweddol o linell syth.",
             "stdForProhibition": false,
             "forVehicleType": ["psv", "hgv"]
           }
@@ -12421,6 +13660,7 @@
     "id": 61,
     "imNumber": 74,
     "imDescription": "Other Dangerous Defects",
+    "imDescriptionWelsh": "Diffygion Peryglus Eraill",
     "forVehicleType": ["hgv", "trl", "psv"],
     "additionalInfo": {
       "psv": {
@@ -12464,6 +13704,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A defect not described elsewhere in the manual such that:",
+        "itemDescriptionWelsh": "Diffyg na ddisgrifir mewn man arall yn y llawlyfr fel:",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {
@@ -12472,6 +13713,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "the use of the vehicle or trailer on the road would involve an immediate danger of injury to any person.",
+            "deficiencyTextWelsh": "byddai defnyddio'r cerbyd neu'r trelar ar y ffordd yn golygu perygl uniongyrchol o anaf i unrhyw berson.",
             "stdForProhibition": true,
             "forVehicleType": ["hgv", "trl"]
           }
@@ -12480,6 +13722,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "A defect not described elsewhere in the manual such that:",
+        "itemDescriptionWelsh": "Diffyg na ddisgrifir mewn man arall yn y llawlyfr fel:",
         "forVehicleType": ["psv"],
         "deficiencies": [
           {
@@ -12488,6 +13731,7 @@
             "deficiencySubId": null,
             "deficiencyCategory": "dangerous",
             "deficiencyText": "the use of the vehicle on the road would involve an immediate danger of injury to any other person.",
+            "deficiencyTextWelsh": "byddai defnyddio'r cerbyd  ar y ffordd yn golygu perygl uniongyrchol o anaf i unrhyw berson arall.",
             "stdForProhibition": true,
             "forVehicleType": ["psv"]
           }


### PR DESCRIPTION
## Add defect taxonomy in Welsh

Add Welsh defect translations into the defect taxonomy as per attached spreadsheet.
Add new versions of the following fields to every defect in the taxonomy to store the Welsh translations:
- imDescription
- itemDescription
- deficiencyText

[VTA-1568](https://dvsa.atlassian.net/browse/VTA-1568)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
