### PR TITLE
fix(remove redundant log from unit test)

### DIFF
--- a/tests/unit/functions/getIvaDefectsByManual.unitTest.ts
+++ b/tests/unit/functions/getIvaDefectsByManual.unitTest.ts
@@ -33,7 +33,6 @@ describe("getIvaDefectsByManualId Function", () => {
     });
 
     it("returns 204 when no data was found", async () => {
-      console.log(IvaDefects);
       mockValidateIvaDefectManualQuery.mockReturnValueOnce(undefined);
       jest
         .spyOn(IvaDefectsService.prototype, "getIvaDefectsByManualId")


### PR DESCRIPTION
## remove redundant log from unit test

removed a log that output the entire M1 manual in a unit test.
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-9695)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
