### PR TITLE
feat(cb2-9988): remove holding branch from pr checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,9 +5,9 @@ name: PR-checks
 
 on:
   push:
-    branches: ["develop", "feature/VTMDEV-1", "feature/CB2-9571"]
+    branches: ["develop", "feature/VTMDEV-1"]
   pull_request:
-    branches: ["develop", "feature/VTMDEV-1", "feature/CB2-9571"]
+    branches: ["develop", "feature/VTMDEV-1"]
 
 jobs:
   build-test:


### PR DESCRIPTION
## Remove the IVA defect holding branch from merge blocking on GitHub actions

Remove the holding branch from GHA now that is has been merged into develop
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-9988)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
