### PR TITLE
CB2-10949: added generic funtion for mapping eu vehicle category

### DIFF
--- a/.github/workflows/build_hash.yml
+++ b/.github/workflows/build_hash.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'feature/*'
+      - "feature/*"
 
 jobs:
   Build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@dvsa/cvs-type-definitions": "6.0.0",
+        "@dvsa/cvs-type-definitions": "6.0.1",
         "aws-lambda": "1.0.7",
         "aws-sdk": "^2.1452.0",
         "aws-xray-sdk": "3.5.1",
@@ -2367,9 +2367,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.0.0.tgz",
-      "integrity": "sha512-jRPP2+J7ZWPUaSvHIaEjs6S2wO2Jd2SSAvEgGoVxKYZAmY0eyu6mIRXdhf2aRLAVXWsI/k4QLOr3ulE7ucUtZg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.0.1.tgz",
+      "integrity": "sha512-R3iwsISsgxIt0Z2TnIpiQmEmhTRcrhNMPtxrUOt6R0Yw9oiLlX4sb+CELjI7BfZZJsGmHZyT55u1yVRwyHcKaw==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@dvsa/cvs-type-definitions": "6.0.0",
+    "@dvsa/cvs-type-definitions": "6.0.1",
     "aws-lambda": "1.0.7",
     "aws-sdk": "^2.1452.0",
     "aws-xray-sdk": "3.5.1",

--- a/src/functions/getRequiredStandards.ts
+++ b/src/functions/getRequiredStandards.ts
@@ -15,15 +15,19 @@ export const getRequiredStandards: Handler = async (
   const requiredStandardsService = new RequiredStandardsService(
     requiredStandardsDatabaseService,
   );
+  const euVehicleCategories = event.multiValueQueryStringParameters?.euVehicleCategory;
 
   const defectErrors = validateRequiredStandardsGetQuery(event);
-
+  if (euVehicleCategories && euVehicleCategories.length > 1) {
+    return new HTTPResponse(400, "Multiple EU Vehicle Categories are not allowed");
+  }
   if (defectErrors) {
     return addHttpHeaders(defectErrors);
   }
 
   const euVehicleCategoryQuery = event?.queryStringParameters
     ?.euVehicleCategory as EUVehicleCategory;
+
   if (!euVehicleCategoryQuery) {
     return new HTTPResponse(400, "euVehicleCategory required");
   } else if (

--- a/src/functions/getRequiredStandards.ts
+++ b/src/functions/getRequiredStandards.ts
@@ -25,6 +25,8 @@ export const getRequiredStandards: Handler = async (
   const euVehicleCategoryQuery = event?.queryStringParameters
     ?.euVehicleCategory as EUVehicleCategory;
 
+  console.log(euVehicleCategoryQuery);
+
   if (!euVehicleCategoryQuery) {
     return new HTTPResponse(400, "euVehicleCategory required");
   } else if (

--- a/src/functions/getRequiredStandards.ts
+++ b/src/functions/getRequiredStandards.ts
@@ -24,9 +24,6 @@ export const getRequiredStandards: Handler = async (
 
   const euVehicleCategoryQuery = event?.queryStringParameters
     ?.euVehicleCategory as EUVehicleCategory;
-
-  console.log(euVehicleCategoryQuery);
-
   if (!euVehicleCategoryQuery) {
     return new HTTPResponse(400, "euVehicleCategory required");
   } else if (

--- a/src/services/requiredStandardsService.ts
+++ b/src/services/requiredStandardsService.ts
@@ -66,11 +66,10 @@ export class RequiredStandardsService {
       ],
       basic: this.formatSections(results, (x) => x.basicInspection),
       normal: this.formatSections(
-        results,
-        (x) =>
-          x.normalInspection || (!x.normalInspection && !x.basicInspection),
+          results,
+          (x) => x.normalInspection || (!x.normalInspection && !x.basicInspection)
       ),
-    } as DefectGETRequiredStandards;
+    } as unknown as DefectGETRequiredStandards;
   }
 
   /**

--- a/src/services/requiredStandardsService.ts
+++ b/src/services/requiredStandardsService.ts
@@ -120,7 +120,6 @@ export class RequiredStandardsService {
   }
 }
 
-
 /**
  * Generic function to retrieve the enum key corresponding to a given string value using a case insensitive search.
  *

--- a/src/services/requiredStandardsService.ts
+++ b/src/services/requiredStandardsService.ts
@@ -58,11 +58,11 @@ export class RequiredStandardsService {
     results: ITaxonomySectionRequiredStandards[],
     euVehicleCategory: string,
   ): DefectGETRequiredStandards {
+    const categoryEnumKey = getEnumKeyByValue(EUVehicleCategory, euVehicleCategory);
+
     return {
       euVehicleCategories: [
-        EUVehicleCategory[
-          euVehicleCategory.toLocaleUpperCase() as keyof typeof EUVehicleCategory
-        ],
+        categoryEnumKey ? EUVehicleCategory[categoryEnumKey] : undefined
       ],
       basic: this.formatSections(results, (x) => x.basicInspection),
       normal: this.formatSections(
@@ -119,3 +119,16 @@ export class RequiredStandardsService {
     });
   }
 }
+
+
+/**
+ * Generic function to retrieve the enum key corresponding to a given string value using a case insensitive search.
+ *
+ * @param enumObj
+ * @param value
+ * @returns {keyof E | null}
+ */
+const getEnumKeyByValue = <E extends Record<string, string>>(enumObj: E, value: string): keyof E | null => (Object.keys(enumObj).find(
+    (key) => enumObj[key].toLowerCase() === value.toLowerCase()
+) as keyof E | null);
+

--- a/tests/integration/requiredStandards.intTest.ts
+++ b/tests/integration/requiredStandards.intTest.ts
@@ -59,6 +59,22 @@ describe("Defects Service", () => {
             expect(res.body).toBe("euVehicleCategory required");
           });
       });
+
+      it("a validation error should be produced where there multiple duplicated query parameters", async () => {
+          await request
+              .get("defects/required-standards?euVehicleCategory=m1&euVehicleCategory=m1")
+              .set({Authorization: mockToken})
+              .then((res: any) => {
+                  expect(res.statusCode).toBe(400);
+                  expect(res.headers["access-control-allow-origin"]).toBe("*");
+                  expect(res.headers["access-control-allow-credentials"]).toBe(
+                      "true",
+                  );
+
+                  expect(res.body).not.toBeNull();
+                  expect(res.body).toBe("Multiple EU Vehicle Categories are not allowed");
+              });
+        });
     });
   });
 });


### PR DESCRIPTION
## MSVA defects missing 'euVehicleCategories' data

This change is to make it so that l1e, l2e and l1e-2 don't have null in the payload.
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-10949)

## Checklist

- [x] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
