### PR TITLE
CB2-10811: Multiple Eu Vehicle Category query parameter restriction

### DIFF
--- a/src/functions/getRequiredStandards.ts
+++ b/src/functions/getRequiredStandards.ts
@@ -15,9 +15,12 @@ export const getRequiredStandards: Handler = async (
   const requiredStandardsService = new RequiredStandardsService(
     requiredStandardsDatabaseService,
   );
+  const euVehicleCategories = event.multiValueQueryStringParameters?.euVehicleCategory;
 
   const defectErrors = validateRequiredStandardsGetQuery(event);
-
+  if (euVehicleCategories && euVehicleCategories.length > 1) {
+    return new HTTPResponse(400, "Multiple EU Vehicle Categories are not allowed");
+  }
   if (defectErrors) {
     return addHttpHeaders(defectErrors);
   }

--- a/tests/integration/requiredStandards.intTest.ts
+++ b/tests/integration/requiredStandards.intTest.ts
@@ -59,6 +59,28 @@ describe("Defects Service", () => {
             expect(res.body).toBe("euVehicleCategory required");
           });
       });
+
+      it("a validation error should be produced where there multiple duplicated query parameters", async () => {
+          const expectedResponse = JSON.parse(
+              JSON.stringify(requiredStandardsData),
+          ).map((defect: { id: any }) => {
+              delete defect.id;
+              return defect;
+          });
+          await request
+              .get("defects/required-standards?euVehicleCategory=m1&euVehicleCategory=m1")
+              .set({Authorization: mockToken})
+              .then((res: any) => {
+                  expect(res.statusCode).toBe(400);
+                  expect(res.headers["access-control-allow-origin"]).toBe("*");
+                  expect(res.headers["access-control-allow-credentials"]).toBe(
+                      "true",
+                  );
+
+                  expect(res.body).not.toBeNull();
+                  expect(res.body).toBe("Multiple EU Vehicle Categories are not allowed");
+              });
+        });
     });
   });
 });

--- a/tests/integration/requiredStandards.intTest.ts
+++ b/tests/integration/requiredStandards.intTest.ts
@@ -61,12 +61,6 @@ describe("Defects Service", () => {
       });
 
       it("a validation error should be produced where there multiple duplicated query parameters", async () => {
-          const expectedResponse = JSON.parse(
-              JSON.stringify(requiredStandardsData),
-          ).map((defect: { id: any }) => {
-              delete defect.id;
-              return defect;
-          });
           await request
               .get("defects/required-standards?euVehicleCategory=m1&euVehicleCategory=m1")
               .set({Authorization: mockToken})


### PR DESCRIPTION
## User able to query with multiple euVehicleCategories

Added validation to the query parameters to prevent multi value query parameters.
[CB-10811](https://dvsa.atlassian.net/browse/CB2-10811)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
