### PR TITLE
Feat(CB2-13098): Reword imDescription for IM44

### DIFF
--- a/tests/resources/defects.json
+++ b/tests/resources/defects.json
@@ -9028,7 +9028,7 @@
     ]
   },
   {
-    "id": 44,
+    "id": 62,
     "imNumber": 44,
     "imDescription": "Oil Leaks",
     "imDescriptionWelsh": "Olew yn Gollwng",

--- a/tests/resources/defects.json
+++ b/tests/resources/defects.json
@@ -8934,30 +8934,6 @@
           "axleNumber": null
         },
         "notes": true
-      },
-      "hgv": {
-        "location": {
-          "vertical": null,
-          "horizontal": null,
-          "lateral": null,
-          "longitudinal": null,
-          "rowNumber": null,
-          "seatNumber": null,
-          "axleNumber": null
-        },
-        "notes": true
-      },
-      "trl": {
-        "location": {
-          "vertical": null,
-          "horizontal": null,
-          "lateral": null,
-          "longitudinal": null,
-          "rowNumber": null,
-          "seatNumber": null,
-          "axleNumber": null
-        },
-        "notes": true
       }
     },
     "items": [
@@ -9063,7 +9039,7 @@
       {
         "itemNumber": 1,
         "itemDescription": "Any oil leak which can deposit",
-        "itemDescriptionWelsh": "Unrhyw ollyngiad olew a all adneuo ",
+        "itemDescriptionWelsh": "Unrhyw ollyngiad olew a all adneuo",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {

--- a/tests/resources/defects.json
+++ b/tests/resources/defects.json
@@ -8921,7 +8921,7 @@
     "imNumber": 44,
     "imDescription": "Oil and Waste Leaks",
     "imDescriptionWelsh": "Gollyngiadau Olew a Gwastraff",
-    "forVehicleType": ["psv", "hgv", "trl"],
+    "forVehicleType": ["psv"],
     "additionalInfo": {
       "psv": {
         "location": {
@@ -9024,11 +9024,46 @@
             "forVehicleType": ["psv"]
           }
         ]
+      }
+    ]
+  },
+  {
+    "id": 44,
+    "imNumber": 44,
+    "imDescription": "Oil Leaks",
+    "imDescriptionWelsh": "Olew yn Gollwng",
+    "forVehicleType": ["hgv", "trl"],
+    "additionalInfo": {
+      "hgv": {
+        "location": {
+          "vertical": null,
+          "horizontal": null,
+          "lateral": null,
+          "longitudinal": null,
+          "rowNumber": null,
+          "seatNumber": null,
+          "axleNumber": null
+        },
+        "notes": true
       },
+      "trl": {
+        "location": {
+          "vertical": null,
+          "horizontal": null,
+          "lateral": null,
+          "longitudinal": null,
+          "rowNumber": null,
+          "seatNumber": null,
+          "axleNumber": null
+        },
+        "notes": true
+      }
+    },
+    "items": [
       {
         "itemNumber": 1,
         "itemDescription": "Any oil leak which can deposit",
-        "itemDescriptionWelsh": "Unrhyw ollyngiad olew a all adneuo",
+        "itemDescriptionWelsh": "Unrhyw ollyngiad olew a all adneuo ",
         "forVehicleType": ["hgv", "trl"],
         "deficiencies": [
           {

--- a/tests/unit/services/requiredStandardsService.unitTest.ts
+++ b/tests/unit/services/requiredStandardsService.unitTest.ts
@@ -272,7 +272,8 @@ describe("required standards  Service", () => {
         RequiredStandards,
       );
 
-      const result = await target.getRequiredStandardsByEUVehicleCategory("test");
+      const result =
+        await target.getRequiredStandardsByEUVehicleCategory("test");
 
       expect(mockGetDefectsByEUVehicleCategory).toHaveBeenCalledTimes(1);
       expect(result?.normal?.length).toBe(635);
@@ -283,7 +284,8 @@ describe("required standards  Service", () => {
         RequiredStandards,
       );
 
-      const result = await target.getRequiredStandardsByEUVehicleCategory("test");
+      const result =
+        await target.getRequiredStandardsByEUVehicleCategory("test");
 
       expect(mockGetDefectsByEUVehicleCategory).toHaveBeenCalledTimes(1);
       expect(result?.basic?.length).toBe(96);


### PR DESCRIPTION
## VTA - Defect categories list IM44 incorrect for HGV and TRL

This change is to change the IM description for IM44 for HGV and TRL. In order to do this, the defect needed to be separated and the HGV/TRL defect id is now 62 and the PSV id has remained as 44.
[CB2-13098](https://dvsa.atlassian.net/browse/CB2-13098)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
